### PR TITLE
UX improvements: PascalCase properties, -Filter support, name-based r…

### DIFF
--- a/MatterMostV4/Formats/MatterMost.Bot.Format.ps1xml
+++ b/MatterMostV4/Formats/MatterMost.Bot.Format.ps1xml
@@ -9,19 +9,17 @@
       </ViewSelectedBy>
       <TableControl>
         <TableHeaders>
-          <TableColumnHeader><Label>User Id</Label><Width>28</Width></TableColumnHeader>
           <TableColumnHeader><Label>Username</Label><Width>22</Width></TableColumnHeader>
-          <TableColumnHeader><Label>Display Name</Label><Width>24</Width></TableColumnHeader>
-          <TableColumnHeader><Label>Owner Id</Label><Width>28</Width></TableColumnHeader>
+          <TableColumnHeader><Label>DisplayName</Label><Width>24</Width></TableColumnHeader>
+          <TableColumnHeader><Label>OwnerId</Label><Width>28</Width></TableColumnHeader>
           <TableColumnHeader><Label>Description</Label></TableColumnHeader>
         </TableHeaders>
         <TableRowEntries>
           <TableRowEntry>
             <TableColumnItems>
-              <TableColumnItem><PropertyName>user_id</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>username</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>display_name</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>owner_id</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>DisplayName</PropertyName></TableColumnItem>
+              <TableColumnItem><PropertyName>OwnerId</PropertyName></TableColumnItem>
               <TableColumnItem><PropertyName>description</PropertyName></TableColumnItem>
             </TableColumnItems>
           </TableRowEntry>

--- a/MatterMostV4/Formats/MatterMost.Channel.Format.ps1xml
+++ b/MatterMostV4/Formats/MatterMost.Channel.Format.ps1xml
@@ -4,50 +4,36 @@
 
     <View>
       <Name>MMChannel.Table</Name>
-      <ViewSelectedBy>
-        <TypeName>MMChannel</TypeName>
-      </ViewSelectedBy>
+      <ViewSelectedBy><TypeName>MMChannel</TypeName></ViewSelectedBy>
       <TableControl>
         <TableHeaders>
-          <TableColumnHeader><Label>Display Name</Label><Width>28</Width></TableColumnHeader>
+          <TableColumnHeader><Label>DisplayName</Label><Width>28</Width></TableColumnHeader>
           <TableColumnHeader><Label>Name</Label><Width>22</Width></TableColumnHeader>
           <TableColumnHeader><Label>Type</Label><Width>8</Width></TableColumnHeader>
           <TableColumnHeader><Label>Purpose</Label></TableColumnHeader>
         </TableHeaders>
-        <TableRowEntries>
-          <TableRowEntry>
-            <TableColumnItems>
-              <TableColumnItem><PropertyName>display_name</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>name</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>type</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>purpose</PropertyName></TableColumnItem>
-            </TableColumnItems>
-          </TableRowEntry>
-        </TableRowEntries>
+        <TableRowEntries><TableRowEntry><TableColumnItems>
+          <TableColumnItem><PropertyName>DisplayName</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>name</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>type</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>purpose</PropertyName></TableColumnItem>
+        </TableColumnItems></TableRowEntry></TableRowEntries>
       </TableControl>
     </View>
 
     <View>
       <Name>MMChannel.List</Name>
-      <ViewSelectedBy>
-        <TypeName>MMChannel</TypeName>
-      </ViewSelectedBy>
-      <ListControl>
-        <ListEntries>
-          <ListEntry>
-            <ListItems>
-              <ListItem><Label>Id</Label><PropertyName>id</PropertyName></ListItem>
-              <ListItem><Label>Name</Label><PropertyName>name</PropertyName></ListItem>
-              <ListItem><Label>Display Name</Label><PropertyName>display_name</PropertyName></ListItem>
-              <ListItem><Label>Type</Label><PropertyName>type</PropertyName></ListItem>
-              <ListItem><Label>Team Id</Label><PropertyName>team_id</PropertyName></ListItem>
-              <ListItem><Label>Purpose</Label><PropertyName>purpose</PropertyName></ListItem>
-              <ListItem><Label>Header</Label><PropertyName>header</PropertyName></ListItem>
-              <ListItem><Label>Total Messages</Label><PropertyName>total_msg_count</PropertyName></ListItem>
-            </ListItems>
-          </ListEntry>
-        </ListEntries>
-      </ListControl>
+      <ViewSelectedBy><TypeName>MMChannel</TypeName></ViewSelectedBy>
+      <ListControl><ListEntries><ListEntry><ListItems>
+        <ListItem><Label>Id</Label><PropertyName>id</PropertyName></ListItem>
+        <ListItem><Label>Name</Label><PropertyName>name</PropertyName></ListItem>
+        <ListItem><Label>DisplayName</Label><PropertyName>DisplayName</PropertyName></ListItem>
+        <ListItem><Label>Type</Label><PropertyName>type</PropertyName></ListItem>
+        <ListItem><Label>TeamId</Label><PropertyName>TeamId</PropertyName></ListItem>
+        <ListItem><Label>Purpose</Label><PropertyName>purpose</PropertyName></ListItem>
+        <ListItem><Label>Header</Label><PropertyName>header</PropertyName></ListItem>
+        <ListItem><Label>TotalMessages</Label><PropertyName>TotalMessages</PropertyName></ListItem>
+      </ListItems></ListEntry></ListEntries></ListControl>
     </View>
 
   </ViewDefinitions>

--- a/MatterMostV4/Formats/MatterMost.ChannelMember.Format.ps1xml
+++ b/MatterMostV4/Formats/MatterMost.ChannelMember.Format.ps1xml
@@ -4,9 +4,7 @@
 
     <View>
       <Name>MatterMost.ChannelMember.Table</Name>
-      <ViewSelectedBy>
-        <TypeName>MMChannelMember</TypeName>
-      </ViewSelectedBy>
+      <ViewSelectedBy><TypeName>MMChannelMember</TypeName></ViewSelectedBy>
       <TableControl>
         <TableHeaders>
           <TableColumnHeader><Label>UserId</Label><Width>26</Width></TableColumnHeader>
@@ -14,16 +12,12 @@
           <TableColumnHeader><Label>MsgCount</Label><Width>10</Width></TableColumnHeader>
           <TableColumnHeader><Label>MentionCount</Label><Width>12</Width></TableColumnHeader>
         </TableHeaders>
-        <TableRowEntries>
-          <TableRowEntry>
-            <TableColumnItems>
-              <TableColumnItem><PropertyName>user_id</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>roles</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>msg_count</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>mention_count</PropertyName></TableColumnItem>
-            </TableColumnItems>
-          </TableRowEntry>
-        </TableRowEntries>
+        <TableRowEntries><TableRowEntry><TableColumnItems>
+          <TableColumnItem><PropertyName>UserId</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>roles</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>MsgCount</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>MentionCount</PropertyName></TableColumnItem>
+        </TableColumnItems></TableRowEntry></TableRowEntries>
       </TableControl>
     </View>
 

--- a/MatterMostV4/Formats/MatterMost.Emoji.Format.ps1xml
+++ b/MatterMostV4/Formats/MatterMost.Emoji.Format.ps1xml
@@ -4,24 +4,16 @@
 
     <View>
       <Name>MMEmoji.Table</Name>
-      <ViewSelectedBy>
-        <TypeName>MMEmoji</TypeName>
-      </ViewSelectedBy>
+      <ViewSelectedBy><TypeName>MMEmoji</TypeName></ViewSelectedBy>
       <TableControl>
         <TableHeaders>
           <TableColumnHeader><Label>Name</Label><Width>24</Width></TableColumnHeader>
-          <TableColumnHeader><Label>Id</Label><Width>28</Width></TableColumnHeader>
-          <TableColumnHeader><Label>Creator Id</Label></TableColumnHeader>
+          <TableColumnHeader><Label>CreatorId</Label></TableColumnHeader>
         </TableHeaders>
-        <TableRowEntries>
-          <TableRowEntry>
-            <TableColumnItems>
-              <TableColumnItem><PropertyName>name</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>id</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>creator_id</PropertyName></TableColumnItem>
-            </TableColumnItems>
-          </TableRowEntry>
-        </TableRowEntries>
+        <TableRowEntries><TableRowEntry><TableColumnItems>
+          <TableColumnItem><PropertyName>name</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>CreatorId</PropertyName></TableColumnItem>
+        </TableColumnItems></TableRowEntry></TableRowEntries>
       </TableControl>
     </View>
 

--- a/MatterMostV4/Formats/MatterMost.File.Format.ps1xml
+++ b/MatterMostV4/Formats/MatterMost.File.Format.ps1xml
@@ -4,54 +4,38 @@
 
     <View>
       <Name>MMFile.Table</Name>
-      <ViewSelectedBy>
-        <TypeName>MMFile</TypeName>
-      </ViewSelectedBy>
+      <ViewSelectedBy><TypeName>MMFile</TypeName></ViewSelectedBy>
       <TableControl>
         <TableHeaders>
           <TableColumnHeader><Label>Name</Label><Width>30</Width></TableColumnHeader>
           <TableColumnHeader><Label>Ext</Label><Width>8</Width></TableColumnHeader>
           <TableColumnHeader><Label>Size</Label><Width>12</Width></TableColumnHeader>
-          <TableColumnHeader><Label>MIME Type</Label><Width>28</Width></TableColumnHeader>
-          <TableColumnHeader><Label>Id</Label></TableColumnHeader>
+          <TableColumnHeader><Label>MimeType</Label></TableColumnHeader>
         </TableHeaders>
-        <TableRowEntries>
-          <TableRowEntry>
-            <TableColumnItems>
-              <TableColumnItem><PropertyName>name</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>extension</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>size</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>mime_type</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>id</PropertyName></TableColumnItem>
-            </TableColumnItems>
-          </TableRowEntry>
-        </TableRowEntries>
+        <TableRowEntries><TableRowEntry><TableColumnItems>
+          <TableColumnItem><PropertyName>name</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>extension</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>size</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>MimeType</PropertyName></TableColumnItem>
+        </TableColumnItems></TableRowEntry></TableRowEntries>
       </TableControl>
     </View>
 
     <View>
       <Name>MMFile.List</Name>
-      <ViewSelectedBy>
-        <TypeName>MMFile</TypeName>
-      </ViewSelectedBy>
-      <ListControl>
-        <ListEntries>
-          <ListEntry>
-            <ListItems>
-              <ListItem><Label>Id</Label><PropertyName>id</PropertyName></ListItem>
-              <ListItem><Label>Name</Label><PropertyName>name</PropertyName></ListItem>
-              <ListItem><Label>Extension</Label><PropertyName>extension</PropertyName></ListItem>
-              <ListItem><Label>MIME Type</Label><PropertyName>mime_type</PropertyName></ListItem>
-              <ListItem><Label>Size</Label><PropertyName>size</PropertyName></ListItem>
-              <ListItem><Label>Width</Label><PropertyName>width</PropertyName></ListItem>
-              <ListItem><Label>Height</Label><PropertyName>height</PropertyName></ListItem>
-              <ListItem><Label>Has Preview</Label><PropertyName>has_preview_image</PropertyName></ListItem>
-              <ListItem><Label>Post Id</Label><PropertyName>post_id</PropertyName></ListItem>
-              <ListItem><Label>User Id</Label><PropertyName>user_id</PropertyName></ListItem>
-            </ListItems>
-          </ListEntry>
-        </ListEntries>
-      </ListControl>
+      <ViewSelectedBy><TypeName>MMFile</TypeName></ViewSelectedBy>
+      <ListControl><ListEntries><ListEntry><ListItems>
+        <ListItem><Label>Id</Label><PropertyName>id</PropertyName></ListItem>
+        <ListItem><Label>Name</Label><PropertyName>name</PropertyName></ListItem>
+        <ListItem><Label>Extension</Label><PropertyName>extension</PropertyName></ListItem>
+        <ListItem><Label>MimeType</Label><PropertyName>MimeType</PropertyName></ListItem>
+        <ListItem><Label>Size</Label><PropertyName>size</PropertyName></ListItem>
+        <ListItem><Label>Width</Label><PropertyName>width</PropertyName></ListItem>
+        <ListItem><Label>Height</Label><PropertyName>height</PropertyName></ListItem>
+        <ListItem><Label>HasPreview</Label><PropertyName>HasPreview</PropertyName></ListItem>
+        <ListItem><Label>PostId</Label><PropertyName>PostId</PropertyName></ListItem>
+        <ListItem><Label>UserId</Label><PropertyName>UserId</PropertyName></ListItem>
+      </ListItems></ListEntry></ListEntries></ListControl>
     </View>
 
   </ViewDefinitions>

--- a/MatterMostV4/Formats/MatterMost.IncomingWebhook.Format.ps1xml
+++ b/MatterMostV4/Formats/MatterMost.IncomingWebhook.Format.ps1xml
@@ -4,48 +4,34 @@
 
     <View>
       <Name>MMIncomingWebhook.Table</Name>
-      <ViewSelectedBy>
-        <TypeName>MMIncomingWebhook</TypeName>
-      </ViewSelectedBy>
+      <ViewSelectedBy><TypeName>MMIncomingWebhook</TypeName></ViewSelectedBy>
       <TableControl>
         <TableHeaders>
-          <TableColumnHeader><Label>Display Name</Label><Width>28</Width></TableColumnHeader>
-          <TableColumnHeader><Label>Channel Id</Label><Width>28</Width></TableColumnHeader>
+          <TableColumnHeader><Label>DisplayName</Label><Width>28</Width></TableColumnHeader>
+          <TableColumnHeader><Label>ChannelId</Label><Width>28</Width></TableColumnHeader>
           <TableColumnHeader><Label>Locked</Label><Width>8</Width></TableColumnHeader>
           <TableColumnHeader><Label>Description</Label></TableColumnHeader>
         </TableHeaders>
-        <TableRowEntries>
-          <TableRowEntry>
-            <TableColumnItems>
-              <TableColumnItem><PropertyName>display_name</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>channel_id</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>channel_locked</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>description</PropertyName></TableColumnItem>
-            </TableColumnItems>
-          </TableRowEntry>
-        </TableRowEntries>
+        <TableRowEntries><TableRowEntry><TableColumnItems>
+          <TableColumnItem><PropertyName>DisplayName</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>ChannelId</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>ChannelLocked</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>description</PropertyName></TableColumnItem>
+        </TableColumnItems></TableRowEntry></TableRowEntries>
       </TableControl>
     </View>
 
     <View>
       <Name>MMIncomingWebhook.List</Name>
-      <ViewSelectedBy>
-        <TypeName>MMIncomingWebhook</TypeName>
-      </ViewSelectedBy>
-      <ListControl>
-        <ListEntries>
-          <ListEntry>
-            <ListItems>
-              <ListItem><Label>Id</Label><PropertyName>id</PropertyName></ListItem>
-              <ListItem><Label>Display Name</Label><PropertyName>display_name</PropertyName></ListItem>
-              <ListItem><Label>Channel Id</Label><PropertyName>channel_id</PropertyName></ListItem>
-              <ListItem><Label>Description</Label><PropertyName>description</PropertyName></ListItem>
-              <ListItem><Label>Username</Label><PropertyName>username</PropertyName></ListItem>
-              <ListItem><Label>Locked</Label><PropertyName>channel_locked</PropertyName></ListItem>
-            </ListItems>
-          </ListEntry>
-        </ListEntries>
-      </ListControl>
+      <ViewSelectedBy><TypeName>MMIncomingWebhook</TypeName></ViewSelectedBy>
+      <ListControl><ListEntries><ListEntry><ListItems>
+        <ListItem><Label>Id</Label><PropertyName>id</PropertyName></ListItem>
+        <ListItem><Label>DisplayName</Label><PropertyName>DisplayName</PropertyName></ListItem>
+        <ListItem><Label>ChannelId</Label><PropertyName>ChannelId</PropertyName></ListItem>
+        <ListItem><Label>Description</Label><PropertyName>description</PropertyName></ListItem>
+        <ListItem><Label>Username</Label><PropertyName>username</PropertyName></ListItem>
+        <ListItem><Label>Locked</Label><PropertyName>ChannelLocked</PropertyName></ListItem>
+      </ListItems></ListEntry></ListEntries></ListControl>
     </View>
 
   </ViewDefinitions>

--- a/MatterMostV4/Formats/MatterMost.OutgoingWebhook.Format.ps1xml
+++ b/MatterMostV4/Formats/MatterMost.OutgoingWebhook.Format.ps1xml
@@ -4,49 +4,35 @@
 
     <View>
       <Name>MMOutgoingWebhook.Table</Name>
-      <ViewSelectedBy>
-        <TypeName>MMOutgoingWebhook</TypeName>
-      </ViewSelectedBy>
+      <ViewSelectedBy><TypeName>MMOutgoingWebhook</TypeName></ViewSelectedBy>
       <TableControl>
         <TableHeaders>
-          <TableColumnHeader><Label>Display Name</Label><Width>28</Width></TableColumnHeader>
-          <TableColumnHeader><Label>Team Id</Label><Width>28</Width></TableColumnHeader>
-          <TableColumnHeader><Label>Trigger Words</Label><Width>24</Width></TableColumnHeader>
+          <TableColumnHeader><Label>DisplayName</Label><Width>28</Width></TableColumnHeader>
+          <TableColumnHeader><Label>TeamId</Label><Width>28</Width></TableColumnHeader>
+          <TableColumnHeader><Label>TriggerWords</Label><Width>24</Width></TableColumnHeader>
           <TableColumnHeader><Label>Description</Label></TableColumnHeader>
         </TableHeaders>
-        <TableRowEntries>
-          <TableRowEntry>
-            <TableColumnItems>
-              <TableColumnItem><PropertyName>display_name</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>team_id</PropertyName></TableColumnItem>
-              <TableColumnItem><ScriptBlock>$_.trigger_words -join ', '</ScriptBlock></TableColumnItem>
-              <TableColumnItem><PropertyName>description</PropertyName></TableColumnItem>
-            </TableColumnItems>
-          </TableRowEntry>
-        </TableRowEntries>
+        <TableRowEntries><TableRowEntry><TableColumnItems>
+          <TableColumnItem><PropertyName>DisplayName</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>TeamId</PropertyName></TableColumnItem>
+          <TableColumnItem><ScriptBlock>$_.trigger_words -join ', '</ScriptBlock></TableColumnItem>
+          <TableColumnItem><PropertyName>description</PropertyName></TableColumnItem>
+        </TableColumnItems></TableRowEntry></TableRowEntries>
       </TableControl>
     </View>
 
     <View>
       <Name>MMOutgoingWebhook.List</Name>
-      <ViewSelectedBy>
-        <TypeName>MMOutgoingWebhook</TypeName>
-      </ViewSelectedBy>
-      <ListControl>
-        <ListEntries>
-          <ListEntry>
-            <ListItems>
-              <ListItem><Label>Id</Label><PropertyName>id</PropertyName></ListItem>
-              <ListItem><Label>Display Name</Label><PropertyName>display_name</PropertyName></ListItem>
-              <ListItem><Label>Team Id</Label><PropertyName>team_id</PropertyName></ListItem>
-              <ListItem><Label>Channel Id</Label><PropertyName>channel_id</PropertyName></ListItem>
-              <ListItem><Label>Description</Label><PropertyName>description</PropertyName></ListItem>
-              <ListItem><Label>Trigger Words</Label><ScriptBlock>$_.trigger_words -join ', '</ScriptBlock></ListItem>
-              <ListItem><Label>Callback URLs</Label><ScriptBlock>$_.callback_urls -join ', '</ScriptBlock></ListItem>
-            </ListItems>
-          </ListEntry>
-        </ListEntries>
-      </ListControl>
+      <ViewSelectedBy><TypeName>MMOutgoingWebhook</TypeName></ViewSelectedBy>
+      <ListControl><ListEntries><ListEntry><ListItems>
+        <ListItem><Label>Id</Label><PropertyName>id</PropertyName></ListItem>
+        <ListItem><Label>DisplayName</Label><PropertyName>DisplayName</PropertyName></ListItem>
+        <ListItem><Label>TeamId</Label><PropertyName>TeamId</PropertyName></ListItem>
+        <ListItem><Label>ChannelId</Label><PropertyName>ChannelId</PropertyName></ListItem>
+        <ListItem><Label>Description</Label><PropertyName>description</PropertyName></ListItem>
+        <ListItem><Label>TriggerWords</Label><ScriptBlock>$_.trigger_words -join ', '</ScriptBlock></ListItem>
+        <ListItem><Label>CallbackUrls</Label><ScriptBlock>$_.callback_urls -join ', '</ScriptBlock></ListItem>
+      </ListItems></ListEntry></ListEntries></ListControl>
     </View>
 
   </ViewDefinitions>

--- a/MatterMostV4/Formats/MatterMost.Post.Format.ps1xml
+++ b/MatterMostV4/Formats/MatterMost.Post.Format.ps1xml
@@ -4,59 +4,45 @@
 
     <View>
       <Name>MMPost.Table</Name>
-      <ViewSelectedBy>
-        <TypeName>MMPost</TypeName>
-      </ViewSelectedBy>
+      <ViewSelectedBy><TypeName>MMPost</TypeName></ViewSelectedBy>
       <TableControl>
         <TableHeaders>
           <TableColumnHeader><Label>Created</Label><Width>20</Width></TableColumnHeader>
-          <TableColumnHeader><Label>User</Label><Width>20</Width></TableColumnHeader>
-          <TableColumnHeader><Label>Channel</Label><Width>20</Width></TableColumnHeader>
+          <TableColumnHeader><Label>UserId</Label><Width>20</Width></TableColumnHeader>
+          <TableColumnHeader><Label>ChannelId</Label><Width>20</Width></TableColumnHeader>
           <TableColumnHeader><Label>Message</Label></TableColumnHeader>
         </TableHeaders>
-        <TableRowEntries>
-          <TableRowEntry>
-            <TableColumnItems>
-              <TableColumnItem>
-                <ScriptBlock>[System.DateTimeOffset]::FromUnixTimeMilliseconds($_.create_at).LocalDateTime.ToString('yyyy-MM-dd HH:mm')</ScriptBlock>
-              </TableColumnItem>
-              <TableColumnItem><PropertyName>user_id</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>channel_id</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>message</PropertyName></TableColumnItem>
-            </TableColumnItems>
-          </TableRowEntry>
-        </TableRowEntries>
+        <TableRowEntries><TableRowEntry><TableColumnItems>
+          <TableColumnItem>
+            <ScriptBlock>[System.DateTimeOffset]::FromUnixTimeMilliseconds($_.create_at).LocalDateTime.ToString('yyyy-MM-dd HH:mm')</ScriptBlock>
+          </TableColumnItem>
+          <TableColumnItem><PropertyName>UserId</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>ChannelId</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>message</PropertyName></TableColumnItem>
+        </TableColumnItems></TableRowEntry></TableRowEntries>
       </TableControl>
     </View>
 
     <View>
       <Name>MMPost.List</Name>
-      <ViewSelectedBy>
-        <TypeName>MMPost</TypeName>
-      </ViewSelectedBy>
-      <ListControl>
-        <ListEntries>
-          <ListEntry>
-            <ListItems>
-              <ListItem><Label>Id</Label><PropertyName>id</PropertyName></ListItem>
-              <ListItem><Label>Channel Id</Label><PropertyName>channel_id</PropertyName></ListItem>
-              <ListItem><Label>User Id</Label><PropertyName>user_id</PropertyName></ListItem>
-              <ListItem><Label>Message</Label><PropertyName>message</PropertyName></ListItem>
-              <ListItem><Label>Root Id</Label><PropertyName>root_id</PropertyName></ListItem>
-              <ListItem><Label>Type</Label><PropertyName>type</PropertyName></ListItem>
-              <ListItem><Label>File Ids</Label><PropertyName>file_ids</PropertyName></ListItem>
-              <ListItem>
-                <Label>Created</Label>
-                <ScriptBlock>[System.DateTimeOffset]::FromUnixTimeMilliseconds($_.create_at).LocalDateTime</ScriptBlock>
-              </ListItem>
-              <ListItem>
-                <Label>Updated</Label>
-                <ScriptBlock>[System.DateTimeOffset]::FromUnixTimeMilliseconds($_.update_at).LocalDateTime</ScriptBlock>
-              </ListItem>
-            </ListItems>
-          </ListEntry>
-        </ListEntries>
-      </ListControl>
+      <ViewSelectedBy><TypeName>MMPost</TypeName></ViewSelectedBy>
+      <ListControl><ListEntries><ListEntry><ListItems>
+        <ListItem><Label>Id</Label><PropertyName>id</PropertyName></ListItem>
+        <ListItem><Label>ChannelId</Label><PropertyName>ChannelId</PropertyName></ListItem>
+        <ListItem><Label>UserId</Label><PropertyName>UserId</PropertyName></ListItem>
+        <ListItem><Label>Message</Label><PropertyName>message</PropertyName></ListItem>
+        <ListItem><Label>RootId</Label><PropertyName>RootId</PropertyName></ListItem>
+        <ListItem><Label>Type</Label><PropertyName>type</PropertyName></ListItem>
+        <ListItem><Label>FileIds</Label><PropertyName>FileIds</PropertyName></ListItem>
+        <ListItem>
+          <Label>Created</Label>
+          <ScriptBlock>[System.DateTimeOffset]::FromUnixTimeMilliseconds($_.create_at).LocalDateTime</ScriptBlock>
+        </ListItem>
+        <ListItem>
+          <Label>Updated</Label>
+          <ScriptBlock>[System.DateTimeOffset]::FromUnixTimeMilliseconds($_.update_at).LocalDateTime</ScriptBlock>
+        </ListItem>
+      </ListItems></ListEntry></ListEntries></ListControl>
     </View>
 
   </ViewDefinitions>

--- a/MatterMostV4/Formats/MatterMost.Role.Format.ps1xml
+++ b/MatterMostV4/Formats/MatterMost.Role.Format.ps1xml
@@ -4,50 +4,34 @@
 
     <View>
       <Name>MMRole.Table</Name>
-      <ViewSelectedBy>
-        <TypeName>MMRole</TypeName>
-      </ViewSelectedBy>
+      <ViewSelectedBy><TypeName>MMRole</TypeName></ViewSelectedBy>
       <TableControl>
         <TableHeaders>
           <TableColumnHeader><Label>Name</Label><Width>28</Width></TableColumnHeader>
-          <TableColumnHeader><Label>Display Name</Label><Width>28</Width></TableColumnHeader>
+          <TableColumnHeader><Label>DisplayName</Label><Width>28</Width></TableColumnHeader>
           <TableColumnHeader><Label>Permissions</Label></TableColumnHeader>
         </TableHeaders>
-        <TableRowEntries>
-          <TableRowEntry>
-            <TableColumnItems>
-              <TableColumnItem><PropertyName>name</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>display_name</PropertyName></TableColumnItem>
-              <TableColumnItem>
-                <ScriptBlock>($_.permissions -join ', ')</ScriptBlock>
-              </TableColumnItem>
-            </TableColumnItems>
-          </TableRowEntry>
-        </TableRowEntries>
+        <TableRowEntries><TableRowEntry><TableColumnItems>
+          <TableColumnItem><PropertyName>name</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>DisplayName</PropertyName></TableColumnItem>
+          <TableColumnItem><ScriptBlock>($_.permissions -join ', ')</ScriptBlock></TableColumnItem>
+        </TableColumnItems></TableRowEntry></TableRowEntries>
       </TableControl>
     </View>
 
     <View>
       <Name>MMRole.List</Name>
-      <ViewSelectedBy>
-        <TypeName>MMRole</TypeName>
-      </ViewSelectedBy>
-      <ListControl>
-        <ListEntries>
-          <ListEntry>
-            <ListItems>
-              <ListItem><Label>Id</Label><PropertyName>id</PropertyName></ListItem>
-              <ListItem><Label>Name</Label><PropertyName>name</PropertyName></ListItem>
-              <ListItem><Label>Display Name</Label><PropertyName>display_name</PropertyName></ListItem>
-              <ListItem><Label>Description</Label><PropertyName>description</PropertyName></ListItem>
-              <ListItem>
-                <Label>Permissions</Label>
-                <ScriptBlock>($_.permissions -join "`n")</ScriptBlock>
-              </ListItem>
-            </ListItems>
-          </ListEntry>
-        </ListEntries>
-      </ListControl>
+      <ViewSelectedBy><TypeName>MMRole</TypeName></ViewSelectedBy>
+      <ListControl><ListEntries><ListEntry><ListItems>
+        <ListItem><Label>Id</Label><PropertyName>id</PropertyName></ListItem>
+        <ListItem><Label>Name</Label><PropertyName>name</PropertyName></ListItem>
+        <ListItem><Label>DisplayName</Label><PropertyName>DisplayName</PropertyName></ListItem>
+        <ListItem><Label>Description</Label><PropertyName>description</PropertyName></ListItem>
+        <ListItem>
+          <Label>Permissions</Label>
+          <ScriptBlock>($_.permissions -join "`n")</ScriptBlock>
+        </ListItem>
+      </ListItems></ListEntry></ListEntries></ListControl>
     </View>
 
   </ViewDefinitions>

--- a/MatterMostV4/Formats/MatterMost.Session.Format.ps1xml
+++ b/MatterMostV4/Formats/MatterMost.Session.Format.ps1xml
@@ -4,52 +4,38 @@
 
     <View>
       <Name>MMSession.Table</Name>
-      <ViewSelectedBy>
-        <TypeName>MMSession</TypeName>
-      </ViewSelectedBy>
+      <ViewSelectedBy><TypeName>MMSession</TypeName></ViewSelectedBy>
       <TableControl>
         <TableHeaders>
           <TableColumnHeader><Label>Id</Label><Width>28</Width></TableColumnHeader>
-          <TableColumnHeader><Label>Device</Label><Width>20</Width></TableColumnHeader>
-          <TableColumnHeader><Label>OAuth</Label><Width>6</Width></TableColumnHeader>
-          <TableColumnHeader><Label>Last Activity</Label><Width>22</Width></TableColumnHeader>
-          <TableColumnHeader><Label>Expires</Label></TableColumnHeader>
+          <TableColumnHeader><Label>DeviceId</Label><Width>20</Width></TableColumnHeader>
+          <TableColumnHeader><Label>IsOAuth</Label><Width>8</Width></TableColumnHeader>
+          <TableColumnHeader><Label>LastActivityAt</Label><Width>22</Width></TableColumnHeader>
+          <TableColumnHeader><Label>ExpiresAt</Label></TableColumnHeader>
         </TableHeaders>
-        <TableRowEntries>
-          <TableRowEntry>
-            <TableColumnItems>
-              <TableColumnItem><PropertyName>id</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>device_id</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>is_oauth</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>last_activity_at</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>expires_at</PropertyName></TableColumnItem>
-            </TableColumnItems>
-          </TableRowEntry>
-        </TableRowEntries>
+        <TableRowEntries><TableRowEntry><TableColumnItems>
+          <TableColumnItem><PropertyName>id</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>DeviceId</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>IsOAuth</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>LastActivityAt</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>ExpiresAt</PropertyName></TableColumnItem>
+        </TableColumnItems></TableRowEntry></TableRowEntries>
       </TableControl>
     </View>
 
     <View>
       <Name>MMSession.List</Name>
-      <ViewSelectedBy>
-        <TypeName>MMSession</TypeName>
-      </ViewSelectedBy>
-      <ListControl>
-        <ListEntries>
-          <ListEntry>
-            <ListItems>
-              <ListItem><Label>Id</Label><PropertyName>id</PropertyName></ListItem>
-              <ListItem><Label>User Id</Label><PropertyName>user_id</PropertyName></ListItem>
-              <ListItem><Label>Device</Label><PropertyName>device_id</PropertyName></ListItem>
-              <ListItem><Label>Roles</Label><PropertyName>roles</PropertyName></ListItem>
-              <ListItem><Label>OAuth</Label><PropertyName>is_oauth</PropertyName></ListItem>
-              <ListItem><Label>Created</Label><PropertyName>create_at</PropertyName></ListItem>
-              <ListItem><Label>Last Activity</Label><PropertyName>last_activity_at</PropertyName></ListItem>
-              <ListItem><Label>Expires</Label><PropertyName>expires_at</PropertyName></ListItem>
-            </ListItems>
-          </ListEntry>
-        </ListEntries>
-      </ListControl>
+      <ViewSelectedBy><TypeName>MMSession</TypeName></ViewSelectedBy>
+      <ListControl><ListEntries><ListEntry><ListItems>
+        <ListItem><Label>Id</Label><PropertyName>id</PropertyName></ListItem>
+        <ListItem><Label>UserId</Label><PropertyName>UserId</PropertyName></ListItem>
+        <ListItem><Label>DeviceId</Label><PropertyName>DeviceId</PropertyName></ListItem>
+        <ListItem><Label>Roles</Label><PropertyName>roles</PropertyName></ListItem>
+        <ListItem><Label>IsOAuth</Label><PropertyName>IsOAuth</PropertyName></ListItem>
+        <ListItem><Label>CreateAt</Label><PropertyName>CreateAt</PropertyName></ListItem>
+        <ListItem><Label>LastActivityAt</Label><PropertyName>LastActivityAt</PropertyName></ListItem>
+        <ListItem><Label>ExpiresAt</Label><PropertyName>ExpiresAt</PropertyName></ListItem>
+      </ListItems></ListEntry></ListEntries></ListControl>
     </View>
 
   </ViewDefinitions>

--- a/MatterMostV4/Formats/MatterMost.Team.Format.ps1xml
+++ b/MatterMostV4/Formats/MatterMost.Team.Format.ps1xml
@@ -4,51 +4,37 @@
 
     <View>
       <Name>MMTeam.Table</Name>
-      <ViewSelectedBy>
-        <TypeName>MMTeam</TypeName>
-      </ViewSelectedBy>
+      <ViewSelectedBy><TypeName>MMTeam</TypeName></ViewSelectedBy>
       <TableControl>
         <TableHeaders>
-          <TableColumnHeader><Label>Display Name</Label><Width>28</Width></TableColumnHeader>
+          <TableColumnHeader><Label>DisplayName</Label><Width>28</Width></TableColumnHeader>
           <TableColumnHeader><Label>Name</Label><Width>22</Width></TableColumnHeader>
           <TableColumnHeader><Label>Type</Label><Width>8</Width></TableColumnHeader>
           <TableColumnHeader><Label>Description</Label></TableColumnHeader>
         </TableHeaders>
-        <TableRowEntries>
-          <TableRowEntry>
-            <TableColumnItems>
-              <TableColumnItem><PropertyName>display_name</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>name</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>type</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>description</PropertyName></TableColumnItem>
-            </TableColumnItems>
-          </TableRowEntry>
-        </TableRowEntries>
+        <TableRowEntries><TableRowEntry><TableColumnItems>
+          <TableColumnItem><PropertyName>DisplayName</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>name</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>type</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>description</PropertyName></TableColumnItem>
+        </TableColumnItems></TableRowEntry></TableRowEntries>
       </TableControl>
     </View>
 
     <View>
       <Name>MMTeam.List</Name>
-      <ViewSelectedBy>
-        <TypeName>MMTeam</TypeName>
-      </ViewSelectedBy>
-      <ListControl>
-        <ListEntries>
-          <ListEntry>
-            <ListItems>
-              <ListItem><Label>Id</Label><PropertyName>id</PropertyName></ListItem>
-              <ListItem><Label>Name</Label><PropertyName>name</PropertyName></ListItem>
-              <ListItem><Label>Display Name</Label><PropertyName>display_name</PropertyName></ListItem>
-              <ListItem><Label>Type</Label><PropertyName>type</PropertyName></ListItem>
-              <ListItem><Label>Description</Label><PropertyName>description</PropertyName></ListItem>
-              <ListItem><Label>Company Name</Label><PropertyName>company_name</PropertyName></ListItem>
-              <ListItem><Label>Email</Label><PropertyName>email</PropertyName></ListItem>
-              <ListItem><Label>Allow Open Invite</Label><PropertyName>allow_open_invite</PropertyName></ListItem>
-              <ListItem><Label>Invite Id</Label><PropertyName>invite_id</PropertyName></ListItem>
-            </ListItems>
-          </ListEntry>
-        </ListEntries>
-      </ListControl>
+      <ViewSelectedBy><TypeName>MMTeam</TypeName></ViewSelectedBy>
+      <ListControl><ListEntries><ListEntry><ListItems>
+        <ListItem><Label>Id</Label><PropertyName>id</PropertyName></ListItem>
+        <ListItem><Label>Name</Label><PropertyName>name</PropertyName></ListItem>
+        <ListItem><Label>DisplayName</Label><PropertyName>DisplayName</PropertyName></ListItem>
+        <ListItem><Label>Type</Label><PropertyName>type</PropertyName></ListItem>
+        <ListItem><Label>Description</Label><PropertyName>description</PropertyName></ListItem>
+        <ListItem><Label>CompanyName</Label><PropertyName>CompanyName</PropertyName></ListItem>
+        <ListItem><Label>Email</Label><PropertyName>email</PropertyName></ListItem>
+        <ListItem><Label>AllowOpenInvite</Label><PropertyName>AllowOpenInvite</PropertyName></ListItem>
+        <ListItem><Label>InviteId</Label><PropertyName>InviteId</PropertyName></ListItem>
+      </ListItems></ListEntry></ListEntries></ListControl>
     </View>
 
   </ViewDefinitions>

--- a/MatterMostV4/Formats/MatterMost.TeamMember.Format.ps1xml
+++ b/MatterMostV4/Formats/MatterMost.TeamMember.Format.ps1xml
@@ -4,24 +4,18 @@
 
     <View>
       <Name>MatterMost.TeamMember.Table</Name>
-      <ViewSelectedBy>
-        <TypeName>MMTeamMember</TypeName>
-      </ViewSelectedBy>
+      <ViewSelectedBy><TypeName>MMTeamMember</TypeName></ViewSelectedBy>
       <TableControl>
         <TableHeaders>
           <TableColumnHeader><Label>UserId</Label><Width>26</Width></TableColumnHeader>
           <TableColumnHeader><Label>Roles</Label><Width>30</Width></TableColumnHeader>
           <TableColumnHeader><Label>SchemeAdmin</Label><Width>12</Width></TableColumnHeader>
         </TableHeaders>
-        <TableRowEntries>
-          <TableRowEntry>
-            <TableColumnItems>
-              <TableColumnItem><PropertyName>user_id</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>roles</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>scheme_admin</PropertyName></TableColumnItem>
-            </TableColumnItems>
-          </TableRowEntry>
-        </TableRowEntries>
+        <TableRowEntries><TableRowEntry><TableColumnItems>
+          <TableColumnItem><PropertyName>UserId</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>roles</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>SchemeAdmin</PropertyName></TableColumnItem>
+        </TableColumnItems></TableRowEntry></TableRowEntries>
       </TableControl>
     </View>
 

--- a/MatterMostV4/Formats/MatterMost.User.Format.ps1xml
+++ b/MatterMostV4/Formats/MatterMost.User.Format.ps1xml
@@ -4,56 +4,42 @@
 
     <View>
       <Name>MMUser.Table</Name>
-      <ViewSelectedBy>
-        <TypeName>MMUser</TypeName>
-      </ViewSelectedBy>
+      <ViewSelectedBy><TypeName>MMUser</TypeName></ViewSelectedBy>
       <TableControl>
         <TableHeaders>
           <TableColumnHeader><Label>Username</Label><Width>22</Width></TableColumnHeader>
           <TableColumnHeader><Label>Email</Label><Width>32</Width></TableColumnHeader>
-          <TableColumnHeader><Label>First Name</Label><Width>14</Width></TableColumnHeader>
-          <TableColumnHeader><Label>Last Name</Label><Width>14</Width></TableColumnHeader>
+          <TableColumnHeader><Label>FirstName</Label><Width>14</Width></TableColumnHeader>
+          <TableColumnHeader><Label>LastName</Label><Width>14</Width></TableColumnHeader>
           <TableColumnHeader><Label>Roles</Label></TableColumnHeader>
         </TableHeaders>
-        <TableRowEntries>
-          <TableRowEntry>
-            <TableColumnItems>
-              <TableColumnItem><PropertyName>username</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>email</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>first_name</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>last_name</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>roles</PropertyName></TableColumnItem>
-            </TableColumnItems>
-          </TableRowEntry>
-        </TableRowEntries>
+        <TableRowEntries><TableRowEntry><TableColumnItems>
+          <TableColumnItem><PropertyName>username</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>email</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>FirstName</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>LastName</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>roles</PropertyName></TableColumnItem>
+        </TableColumnItems></TableRowEntry></TableRowEntries>
       </TableControl>
     </View>
 
     <View>
       <Name>MMUser.List</Name>
-      <ViewSelectedBy>
-        <TypeName>MMUser</TypeName>
-      </ViewSelectedBy>
-      <ListControl>
-        <ListEntries>
-          <ListEntry>
-            <ListItems>
-              <ListItem><Label>Id</Label><PropertyName>id</PropertyName></ListItem>
-              <ListItem><Label>Username</Label><PropertyName>username</PropertyName></ListItem>
-              <ListItem><Label>Email</Label><PropertyName>email</PropertyName></ListItem>
-              <ListItem><Label>First Name</Label><PropertyName>first_name</PropertyName></ListItem>
-              <ListItem><Label>Last Name</Label><PropertyName>last_name</PropertyName></ListItem>
-              <ListItem><Label>Nickname</Label><PropertyName>nickname</PropertyName></ListItem>
-              <ListItem><Label>Position</Label><PropertyName>position</PropertyName></ListItem>
-              <ListItem><Label>Roles</Label><PropertyName>roles</PropertyName></ListItem>
-              <ListItem><Label>Locale</Label><PropertyName>locale</PropertyName></ListItem>
-              <ListItem><Label>Email Verified</Label><PropertyName>email_verified</PropertyName></ListItem>
-              <ListItem><Label>MFA Active</Label><PropertyName>mfa_active</PropertyName></ListItem>
-              <ListItem><Label>Auth Service</Label><PropertyName>auth_service</PropertyName></ListItem>
-            </ListItems>
-          </ListEntry>
-        </ListEntries>
-      </ListControl>
+      <ViewSelectedBy><TypeName>MMUser</TypeName></ViewSelectedBy>
+      <ListControl><ListEntries><ListEntry><ListItems>
+        <ListItem><Label>Id</Label><PropertyName>id</PropertyName></ListItem>
+        <ListItem><Label>Username</Label><PropertyName>username</PropertyName></ListItem>
+        <ListItem><Label>Email</Label><PropertyName>email</PropertyName></ListItem>
+        <ListItem><Label>FirstName</Label><PropertyName>FirstName</PropertyName></ListItem>
+        <ListItem><Label>LastName</Label><PropertyName>LastName</PropertyName></ListItem>
+        <ListItem><Label>Nickname</Label><PropertyName>nickname</PropertyName></ListItem>
+        <ListItem><Label>Position</Label><PropertyName>position</PropertyName></ListItem>
+        <ListItem><Label>Roles</Label><PropertyName>roles</PropertyName></ListItem>
+        <ListItem><Label>Locale</Label><PropertyName>locale</PropertyName></ListItem>
+        <ListItem><Label>EmailVerified</Label><PropertyName>EmailVerified</PropertyName></ListItem>
+        <ListItem><Label>MfaActive</Label><PropertyName>MfaActive</PropertyName></ListItem>
+        <ListItem><Label>AuthService</Label><PropertyName>AuthService</PropertyName></ListItem>
+      </ListItems></ListEntry></ListEntries></ListControl>
     </View>
 
   </ViewDefinitions>

--- a/MatterMostV4/Formats/MatterMost.UserStatus.Format.ps1xml
+++ b/MatterMostV4/Formats/MatterMost.UserStatus.Format.ps1xml
@@ -4,26 +4,20 @@
 
     <View>
       <Name>MMUserStatus.Table</Name>
-      <ViewSelectedBy>
-        <TypeName>MMUserStatus</TypeName>
-      </ViewSelectedBy>
+      <ViewSelectedBy><TypeName>MMUserStatus</TypeName></ViewSelectedBy>
       <TableControl>
         <TableHeaders>
-          <TableColumnHeader><Label>User Id</Label><Width>28</Width></TableColumnHeader>
+          <TableColumnHeader><Label>UserId</Label><Width>28</Width></TableColumnHeader>
           <TableColumnHeader><Label>Status</Label><Width>10</Width></TableColumnHeader>
           <TableColumnHeader><Label>Manual</Label><Width>8</Width></TableColumnHeader>
-          <TableColumnHeader><Label>Last Activity</Label></TableColumnHeader>
+          <TableColumnHeader><Label>LastActivityAt</Label></TableColumnHeader>
         </TableHeaders>
-        <TableRowEntries>
-          <TableRowEntry>
-            <TableColumnItems>
-              <TableColumnItem><PropertyName>user_id</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>status</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>manual</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>last_activity_at</PropertyName></TableColumnItem>
-            </TableColumnItems>
-          </TableRowEntry>
-        </TableRowEntries>
+        <TableRowEntries><TableRowEntry><TableColumnItems>
+          <TableColumnItem><PropertyName>UserId</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>status</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>manual</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>LastActivityAt</PropertyName></TableColumnItem>
+        </TableColumnItems></TableRowEntry></TableRowEntries>
       </TableControl>
     </View>
 

--- a/MatterMostV4/Formats/MatterMost.UserToken.Format.ps1xml
+++ b/MatterMostV4/Formats/MatterMost.UserToken.Format.ps1xml
@@ -4,26 +4,20 @@
 
     <View>
       <Name>MMUserToken.Table</Name>
-      <ViewSelectedBy>
-        <TypeName>MMUserToken</TypeName>
-      </ViewSelectedBy>
+      <ViewSelectedBy><TypeName>MMUserToken</TypeName></ViewSelectedBy>
       <TableControl>
         <TableHeaders>
           <TableColumnHeader><Label>Id</Label><Width>28</Width></TableColumnHeader>
-          <TableColumnHeader><Label>User Id</Label><Width>28</Width></TableColumnHeader>
-          <TableColumnHeader><Label>Active</Label><Width>8</Width></TableColumnHeader>
+          <TableColumnHeader><Label>UserId</Label><Width>28</Width></TableColumnHeader>
+          <TableColumnHeader><Label>IsActive</Label><Width>8</Width></TableColumnHeader>
           <TableColumnHeader><Label>Description</Label></TableColumnHeader>
         </TableHeaders>
-        <TableRowEntries>
-          <TableRowEntry>
-            <TableColumnItems>
-              <TableColumnItem><PropertyName>id</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>user_id</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>is_active</PropertyName></TableColumnItem>
-              <TableColumnItem><PropertyName>description</PropertyName></TableColumnItem>
-            </TableColumnItems>
-          </TableRowEntry>
-        </TableRowEntries>
+        <TableRowEntries><TableRowEntry><TableColumnItems>
+          <TableColumnItem><PropertyName>id</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>UserId</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>IsActive</PropertyName></TableColumnItem>
+          <TableColumnItem><PropertyName>description</PropertyName></TableColumnItem>
+        </TableColumnItems></TableRowEntry></TableRowEntries>
       </TableControl>
     </View>
 

--- a/MatterMostV4/MatterMost.Types.ps1xml
+++ b/MatterMostV4/MatterMost.Types.ps1xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Types>
+
+  <!-- MMChannel -->
+  <Type>
+    <Name>MMChannel</Name>
+    <Members>
+      <ScriptProperty><Name>DisplayName</Name><GetScriptBlock>$this.display_name</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>TeamId</Name><GetScriptBlock>$this.team_id</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>TotalMessages</Name><GetScriptBlock>$this.total_msg_count</GetScriptBlock></ScriptProperty>
+    </Members>
+  </Type>
+
+  <!-- MMUser -->
+  <Type>
+    <Name>MMUser</Name>
+    <Members>
+      <ScriptProperty><Name>FirstName</Name><GetScriptBlock>$this.first_name</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>LastName</Name><GetScriptBlock>$this.last_name</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>EmailVerified</Name><GetScriptBlock>$this.email_verified</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>MfaActive</Name><GetScriptBlock>$this.mfa_active</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>AuthService</Name><GetScriptBlock>$this.auth_service</GetScriptBlock></ScriptProperty>
+    </Members>
+  </Type>
+
+  <!-- MMBot -->
+  <Type>
+    <Name>MMBot</Name>
+    <Members>
+      <ScriptProperty><Name>UserId</Name><GetScriptBlock>$this.user_id</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>DisplayName</Name><GetScriptBlock>$this.display_name</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>OwnerId</Name><GetScriptBlock>$this.owner_id</GetScriptBlock></ScriptProperty>
+    </Members>
+  </Type>
+
+  <!-- MMIncomingWebhook -->
+  <Type>
+    <Name>MMIncomingWebhook</Name>
+    <Members>
+      <ScriptProperty><Name>DisplayName</Name><GetScriptBlock>$this.display_name</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>ChannelId</Name><GetScriptBlock>$this.channel_id</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>ChannelLocked</Name><GetScriptBlock>$this.channel_locked</GetScriptBlock></ScriptProperty>
+    </Members>
+  </Type>
+
+  <!-- MMOutgoingWebhook -->
+  <Type>
+    <Name>MMOutgoingWebhook</Name>
+    <Members>
+      <ScriptProperty><Name>DisplayName</Name><GetScriptBlock>$this.display_name</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>TeamId</Name><GetScriptBlock>$this.team_id</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>ChannelId</Name><GetScriptBlock>$this.channel_id</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>TriggerWords</Name><GetScriptBlock>$this.trigger_words</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>CallbackUrls</Name><GetScriptBlock>$this.callback_urls</GetScriptBlock></ScriptProperty>
+    </Members>
+  </Type>
+
+  <!-- MMPost -->
+  <Type>
+    <Name>MMPost</Name>
+    <Members>
+      <ScriptProperty><Name>ChannelId</Name><GetScriptBlock>$this.channel_id</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>UserId</Name><GetScriptBlock>$this.user_id</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>RootId</Name><GetScriptBlock>$this.root_id</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>FileIds</Name><GetScriptBlock>$this.file_ids</GetScriptBlock></ScriptProperty>
+    </Members>
+  </Type>
+
+  <!-- MMFile -->
+  <Type>
+    <Name>MMFile</Name>
+    <Members>
+      <ScriptProperty><Name>MimeType</Name><GetScriptBlock>$this.mime_type</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>HasPreview</Name><GetScriptBlock>$this.has_preview_image</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>PostId</Name><GetScriptBlock>$this.post_id</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>UserId</Name><GetScriptBlock>$this.user_id</GetScriptBlock></ScriptProperty>
+    </Members>
+  </Type>
+
+  <!-- MMSession -->
+  <Type>
+    <Name>MMSession</Name>
+    <Members>
+      <ScriptProperty><Name>UserId</Name><GetScriptBlock>$this.user_id</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>DeviceId</Name><GetScriptBlock>$this.device_id</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>IsOAuth</Name><GetScriptBlock>$this.is_oauth</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>LastActivityAt</Name><GetScriptBlock>$this.last_activity_at</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>ExpiresAt</Name><GetScriptBlock>$this.expires_at</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>CreateAt</Name><GetScriptBlock>$this.create_at</GetScriptBlock></ScriptProperty>
+    </Members>
+  </Type>
+
+  <!-- MMTeam -->
+  <Type>
+    <Name>MMTeam</Name>
+    <Members>
+      <ScriptProperty><Name>DisplayName</Name><GetScriptBlock>$this.display_name</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>CompanyName</Name><GetScriptBlock>$this.company_name</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>AllowOpenInvite</Name><GetScriptBlock>$this.allow_open_invite</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>InviteId</Name><GetScriptBlock>$this.invite_id</GetScriptBlock></ScriptProperty>
+    </Members>
+  </Type>
+
+  <!-- MMTeamMember -->
+  <Type>
+    <Name>MMTeamMember</Name>
+    <Members>
+      <ScriptProperty><Name>UserId</Name><GetScriptBlock>$this.user_id</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>TeamId</Name><GetScriptBlock>$this.team_id</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>SchemeAdmin</Name><GetScriptBlock>$this.scheme_admin</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>SchemeUser</Name><GetScriptBlock>$this.scheme_user</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>SchemeGuest</Name><GetScriptBlock>$this.scheme_guest</GetScriptBlock></ScriptProperty>
+    </Members>
+  </Type>
+
+  <!-- MMChannelMember -->
+  <Type>
+    <Name>MMChannelMember</Name>
+    <Members>
+      <ScriptProperty><Name>UserId</Name><GetScriptBlock>$this.user_id</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>ChannelId</Name><GetScriptBlock>$this.channel_id</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>MsgCount</Name><GetScriptBlock>$this.msg_count</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>MentionCount</Name><GetScriptBlock>$this.mention_count</GetScriptBlock></ScriptProperty>
+    </Members>
+  </Type>
+
+  <!-- MMEmoji -->
+  <Type>
+    <Name>MMEmoji</Name>
+    <Members>
+      <ScriptProperty><Name>CreatorId</Name><GetScriptBlock>$this.creator_id</GetScriptBlock></ScriptProperty>
+    </Members>
+  </Type>
+
+  <!-- MMUserStatus -->
+  <Type>
+    <Name>MMUserStatus</Name>
+    <Members>
+      <ScriptProperty><Name>UserId</Name><GetScriptBlock>$this.user_id</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>LastActivityAt</Name><GetScriptBlock>$this.last_activity_at</GetScriptBlock></ScriptProperty>
+    </Members>
+  </Type>
+
+  <!-- MMUserToken -->
+  <Type>
+    <Name>MMUserToken</Name>
+    <Members>
+      <ScriptProperty><Name>UserId</Name><GetScriptBlock>$this.user_id</GetScriptBlock></ScriptProperty>
+      <ScriptProperty><Name>IsActive</Name><GetScriptBlock>$this.is_active</GetScriptBlock></ScriptProperty>
+    </Members>
+  </Type>
+
+  <!-- MMRole -->
+  <Type>
+    <Name>MMRole</Name>
+    <Members>
+      <ScriptProperty><Name>DisplayName</Name><GetScriptBlock>$this.display_name</GetScriptBlock></ScriptProperty>
+    </Members>
+  </Type>
+
+</Types>

--- a/MatterMostV4/MatterMostV4.psd1
+++ b/MatterMostV4/MatterMostV4.psd1
@@ -117,6 +117,9 @@
         'Formats/MatterMost.UserToken.Format.ps1xml'
         'Formats/MatterMost.Bot.Format.ps1xml'
     )
+    TypesToProcess    = @(
+        'MatterMost.Types.ps1xml'
+    )
     CmdletsToExport   = @()
     VariablesToExport = @()
     AliasesToExport   = @()

--- a/MatterMostV4/Public/Bots/Get-MMBot.ps1
+++ b/MatterMostV4/Public/Bots/Get-MMBot.ps1
@@ -3,7 +3,7 @@
 function Get-MMBot {
     <#
     .SYNOPSIS
-        Gets a MatterMost bot by ID, or returns a list of bots.
+        Gets a MatterMost bot by ID, returns a list of bots, or filters bots by expression.
     .EXAMPLE
         Get-MMBot
     .EXAMPLE
@@ -12,6 +12,8 @@ function Get-MMBot {
         Get-MMBot -IncludeDeleted
     .EXAMPLE
         Get-MMBot -OnlyOrphaned
+    .EXAMPLE
+        Get-MMBot -Filter { $_.username -like 'ci*' }
     #>
     [CmdletBinding(DefaultParameterSetName = 'List')]
     [OutputType('MMBot')]
@@ -20,21 +22,42 @@ function Get-MMBot {
         [string]$BotUserId,
 
         [Parameter(ParameterSetName = 'List')]
+        [Parameter(ParameterSetName = 'Filter')]
         [switch]$IncludeDeleted,
 
         [Parameter(ParameterSetName = 'List')]
+        [Parameter(ParameterSetName = 'Filter')]
         [switch]$OnlyOrphaned,
 
         [Parameter(ParameterSetName = 'List')]
         [int]$Page = 0,
 
         [Parameter(ParameterSetName = 'List')]
-        [int]$PerPage = 60
+        [int]$PerPage = 60,
+
+        [Parameter(Mandatory, ParameterSetName = 'Filter')]
+        [scriptblock]$Filter
     )
 
     process {
         if ($PSCmdlet.ParameterSetName -eq 'ById') {
             Invoke-MMRequest -Endpoint "bots/$BotUserId" -Method GET | ConvertTo-MMBot
+            return
+        }
+
+        if ($PSCmdlet.ParameterSetName -eq 'Filter') {
+            $page    = 0
+            $perPage = 60
+            $all     = @()
+            do {
+                $query = "page=$page&per_page=$perPage"
+                if ($IncludeDeleted) { $query += '&include_deleted=true' }
+                if ($OnlyOrphaned)   { $query += '&only_orphaned=true' }
+                $batch = Invoke-MMRequest -Endpoint "bots?$query" -Method GET
+                $all  += $batch
+                $page++
+            } while ($batch.Count -eq $perPage)
+            $all | ConvertTo-MMBot | Where-Object $Filter
             return
         }
 

--- a/MatterMostV4/Public/Channels/Get-MMChannel.ps1
+++ b/MatterMostV4/Public/Channels/Get-MMChannel.ps1
@@ -3,7 +3,7 @@
 function Get-MMChannel {
     <#
     .SYNOPSIS
-        Returns a MatterMost channel by ID, name within a team, team channel list, or all channels.
+        Returns a MatterMost channel by ID, name within a team, team channel list, all channels, or filtered by expression.
     .EXAMPLE
         Get-MMChannel -All
     .EXAMPLE
@@ -12,6 +12,10 @@ function Get-MMChannel {
         Get-MMChannel -TeamId 'team123' -Name 'general'
     .EXAMPLE
         Get-MMChannel -TeamId 'team123'
+    .EXAMPLE
+        Get-MMChannel -Filter { $_.name -like 'dev*' }
+    .EXAMPLE
+        Get-MMChannel -TeamId 'team123' -Filter { $_.type -eq 'O' }
     #>
     [OutputType('MMChannel')]
     [CmdletBinding(DefaultParameterSetName = 'ByTeam')]
@@ -25,10 +29,14 @@ function Get-MMChannel {
 
         [Parameter(ParameterSetName = 'ByName')]
         [Parameter(ParameterSetName = 'ByTeam')]
+        [Parameter(ParameterSetName = 'Filter')]
         [string]$TeamId,
 
         [Parameter(Mandatory, ParameterSetName = 'ByName', Position = 0)]
-        [string]$Name
+        [string]$Name,
+
+        [Parameter(Mandatory, ParameterSetName = 'Filter')]
+        [scriptblock]$Filter
     )
 
     process {
@@ -56,6 +64,18 @@ function Get-MMChannel {
                     $batch | ConvertTo-MMChannel
                     $page++
                 } while ($batch.Count -eq $perPage)
+            }
+            'Filter' {
+                $resolvedTeamId = if ($TeamId) { $TeamId } else { Get-MMDefaultTeamId }
+                $page    = 0
+                $perPage = 200
+                $fetched = @()
+                do {
+                    $batch   = Invoke-MMRequest -Endpoint "teams/$resolvedTeamId/channels?page=$page&per_page=$perPage"
+                    $fetched += $batch
+                    $page++
+                } while ($batch.Count -eq $perPage)
+                $fetched | ConvertTo-MMChannel | Where-Object $Filter
             }
         }
     }

--- a/MatterMostV4/Public/Channels/Get-MMChannelMembers.ps1
+++ b/MatterMostV4/Public/Channels/Get-MMChannelMembers.ps1
@@ -7,21 +7,35 @@ function Get-MMChannelMembers {
     .EXAMPLE
         Get-MMChannelMembers -ChannelId 'abc123'
     .EXAMPLE
+        Get-MMChannelMembers -ChannelName 'general'
+    .EXAMPLE
         Get-MMChannel -Name 'general' | Get-MMChannelMembers
     #>
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ById')]
     [OutputType('MMChannelMember')]
     param(
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'ById', ValueFromPipelineByPropertyName)]
         [Alias('id')]
-        [string]$ChannelId
+        [string]$ChannelId,
+
+        [Parameter(Mandatory, ParameterSetName = 'ByName')]
+        [string]$ChannelName,
+
+        [Parameter(ParameterSetName = 'ByName')]
+        [string]$TeamId
     )
 
     process {
+        $resolvedId = if ($PSCmdlet.ParameterSetName -eq 'ByName') {
+            (Get-MMChannel -Name $ChannelName -TeamId $TeamId).id
+        } else {
+            $ChannelId
+        }
+
         $page    = 0
         $perPage = 200
         do {
-            $batch = Invoke-MMRequest -Endpoint "channels/$ChannelId/members?page=$page&per_page=$perPage"
+            $batch = Invoke-MMRequest -Endpoint "channels/$resolvedId/members?page=$page&per_page=$perPage"
             $batch | ConvertTo-MMChannelMember
             $page++
         } while ($batch.Count -eq $perPage)

--- a/MatterMostV4/Public/Channels/Get-MMUserChannels.ps1
+++ b/MatterMostV4/Public/Channels/Get-MMUserChannels.ps1
@@ -7,20 +7,40 @@ function Get-MMUserChannels {
     .EXAMPLE
         Get-MMUserChannels -UserId 'user123' -TeamId 'team456'
     .EXAMPLE
-        Get-MMUser -Username 'jdoe' | Get-MMUserChannels -TeamId 'team456'
+        Get-MMUserChannels -Username 'jdoe' -TeamName 'my-team'
+    .EXAMPLE
+        Get-MMUser -Username 'jdoe' | Get-MMUserChannels -TeamName 'my-team'
     #>
     [OutputType('MMChannel')]
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ById')]
     param(
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'ById', ValueFromPipelineByPropertyName)]
         [Alias('id')]
         [string]$UserId,
 
-        [Parameter(Mandatory)]
-        [string]$TeamId
+        [Parameter(Mandatory, ParameterSetName = 'ById')]
+        [string]$TeamId,
+
+        [Parameter(Mandatory, ParameterSetName = 'ByName')]
+        [string]$Username,
+
+        [Parameter(Mandatory, ParameterSetName = 'ByName')]
+        [string]$TeamName
     )
 
     process {
-        Invoke-MMRequest -Endpoint "users/$UserId/teams/$TeamId/channels" | ConvertTo-MMChannel
+        $resolvedUserId = if ($PSCmdlet.ParameterSetName -eq 'ByName') {
+            (Get-MMUser -Username $Username).id
+        } else {
+            $UserId
+        }
+
+        $resolvedTeamId = if ($PSCmdlet.ParameterSetName -eq 'ByName') {
+            (Get-MMTeam -Name $TeamName).id
+        } else {
+            $TeamId
+        }
+
+        Invoke-MMRequest -Endpoint "users/$resolvedUserId/teams/$resolvedTeamId/channels" | ConvertTo-MMChannel
     }
 }

--- a/MatterMostV4/Public/Channels/New-MMChannel.ps1
+++ b/MatterMostV4/Public/Channels/New-MMChannel.ps1
@@ -7,12 +7,18 @@ function New-MMChannel {
     .EXAMPLE
         New-MMChannel -TeamId 'team123' -Name 'mychannel' -DisplayName 'My Channel'
     .EXAMPLE
+        New-MMChannel -TeamName 'myteam' -Name 'mychannel' -DisplayName 'My Channel'
+    .EXAMPLE
         New-MMChannel -TeamId 'team123' -Name 'private' -DisplayName 'Private Channel' -Type Private
     #>
     [OutputType('MMChannel')]
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ById')]
     param(
+        [Parameter(ParameterSetName = 'ById')]
         [string]$TeamId,
+
+        [Parameter(Mandatory, ParameterSetName = 'ByName')]
+        [string]$TeamName,
 
         [Parameter(Mandatory)]
         [string]$Name,
@@ -20,7 +26,6 @@ function New-MMChannel {
         [Parameter(Mandatory)]
         [string]$DisplayName,
 
-        # Public — открытый канал, Private — закрытый
         [ValidateSet('Public', 'Private')]
         [string]$Type = 'Public',
 
@@ -28,7 +33,13 @@ function New-MMChannel {
         [string]$Header
     )
 
-    $resolvedTeamId = if ($TeamId) { $TeamId } else { Get-MMDefaultTeamId }
+    $resolvedTeamId = if ($PSCmdlet.ParameterSetName -eq 'ByName') {
+        (Get-MMTeam -Name $TeamName).id
+    } elseif ($TeamId) {
+        $TeamId
+    } else {
+        Get-MMDefaultTeamId
+    }
 
     $body = @{
         team_id      = $resolvedTeamId

--- a/MatterMostV4/Public/Connections/Connect-MMServer.ps1
+++ b/MatterMostV4/Public/Connections/Connect-MMServer.ps1
@@ -8,7 +8,7 @@ function Connect-MMServer {
         Поддерживает три способа аутентификации: PSCredential, Username/Password или Personal Access Token.
         После успешного подключения токен сохраняется в $script:MMSession и используется автоматически всеми командлетами модуля.
     .EXAMPLE
-        Connect-MMServer -Url "http://localhost:8065" -Username "admin" -Password "Admin123456!"
+        Connect-MMServer -Url "http://localhost:8065" -Username "admin" -Password (ConvertTo-SecureString "Admin123456!" -AsPlainText -Force)
     .EXAMPLE
         Connect-MMServer -Url "http://localhost:8065" -Credential (Get-Credential)
     .EXAMPLE

--- a/MatterMostV4/Public/Files/Send-MMFile.ps1
+++ b/MatterMostV4/Public/Files/Send-MMFile.ps1
@@ -7,20 +7,34 @@ function Send-MMFile {
     .EXAMPLE
         Send-MMFile -FilePath 'C:\report.pdf' -ChannelId 'abc123'
     .EXAMPLE
+        Send-MMFile -FilePath 'C:\report.pdf' -ChannelName 'general'
+    .EXAMPLE
         Get-MMChannel -Name 'general' | Send-MMFile -FilePath 'C:\report.pdf'
     #>
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ById')]
     [OutputType('MMFile')]
     param(
         [Parameter(Mandatory)]
         [string]$FilePath,
 
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'ById', ValueFromPipelineByPropertyName)]
         [Alias('id')]
-        [string]$ChannelId
+        [string]$ChannelId,
+
+        [Parameter(Mandatory, ParameterSetName = 'ByName')]
+        [string]$ChannelName,
+
+        [Parameter(ParameterSetName = 'ByName')]
+        [string]$TeamId
     )
 
     process {
-        Invoke-MMFileUpload -FilePath $FilePath -ChannelId $ChannelId | ConvertTo-MMFile
+        $resolvedId = if ($PSCmdlet.ParameterSetName -eq 'ByName') {
+            (Get-MMChannel -Name $ChannelName -TeamId $TeamId).id
+        } else {
+            $ChannelId
+        }
+
+        Invoke-MMFileUpload -FilePath $FilePath -ChannelId $resolvedId | ConvertTo-MMFile
     }
 }

--- a/MatterMostV4/Public/Posts/Get-MMChannelPosts.ps1
+++ b/MatterMostV4/Public/Posts/Get-MMChannelPosts.ps1
@@ -7,16 +7,24 @@ function Get-MMChannelPosts {
     .EXAMPLE
         Get-MMChannelPosts -ChannelId 'abc123'
     .EXAMPLE
+        Get-MMChannelPosts -ChannelName 'general'
+    .EXAMPLE
         Get-MMChannel -Name 'general' | Get-MMChannelPosts -Page 0 -PerPage 20
     .EXAMPLE
         Get-MMChannelPosts -ChannelId 'abc123' -Since 1700000000000
     #>
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ById')]
     [OutputType('MMPost')]
     param(
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'ById', ValueFromPipelineByPropertyName)]
         [Alias('id')]
         [string]$ChannelId,
+
+        [Parameter(Mandatory, ParameterSetName = 'ByName')]
+        [string]$ChannelName,
+
+        [Parameter(ParameterSetName = 'ByName')]
+        [string]$TeamId,
 
         [Parameter()]
         [int]$Page = 0,
@@ -24,7 +32,6 @@ function Get-MMChannelPosts {
         [Parameter()]
         [int]$PerPage = 60,
 
-        # Unix timestamp в миллисекундах — вернуть посты изменённые после этого момента
         [Parameter()]
         [long]$Since,
 
@@ -33,13 +40,18 @@ function Get-MMChannelPosts {
     )
 
     process {
+        $resolvedId = if ($PSCmdlet.ParameterSetName -eq 'ByName') {
+            (Get-MMChannel -Name $ChannelName -TeamId $TeamId).id
+        } else {
+            $ChannelId
+        }
+
         $query = "page=$Page&per_page=$PerPage"
-        if ($Since)           { $query += "&since=$Since" }
-        if ($IncludeDeleted)  { $query += "&include_deleted=true" }
+        if ($Since)          { $query += "&since=$Since" }
+        if ($IncludeDeleted) { $query += "&include_deleted=true" }
 
-        $response = Invoke-MMRequest -Endpoint "channels/$ChannelId/posts?$query"
+        $response = Invoke-MMRequest -Endpoint "channels/$resolvedId/posts?$query"
 
-        # API возвращает { order: [...], posts: { id: PostObject, ... } }
         if ($response.order -and $response.posts) {
             foreach ($postId in $response.order) {
                 $response.posts.$postId | ConvertTo-MMPost

--- a/MatterMostV4/Public/Status/Get-MMUserStatus.ps1
+++ b/MatterMostV4/Public/Status/Get-MMUserStatus.ps1
@@ -7,6 +7,8 @@ function Get-MMUserStatus {
     .EXAMPLE
         Get-MMUserStatus -UserId 'abc123'
     .EXAMPLE
+        Get-MMUserStatus -Username 'john'
+    .EXAMPLE
         Get-MMUserStatus -UserIds @('abc123', 'def456')
     .EXAMPLE
         Get-MMUser -Username 'john' | Get-MMUserStatus
@@ -18,6 +20,9 @@ function Get-MMUserStatus {
         [Alias('id', 'user_id')]
         [string]$UserId,
 
+        [Parameter(Mandatory, ParameterSetName = 'ByName')]
+        [string]$Username,
+
         [Parameter(Mandatory, ParameterSetName = 'Batch')]
         [string[]]$UserIds
     )
@@ -26,6 +31,9 @@ function Get-MMUserStatus {
         if ($PSCmdlet.ParameterSetName -eq 'Batch') {
             Invoke-MMRequest -Endpoint 'users/status/ids' -Method POST -Body $UserIds |
                 ForEach-Object { $_ | ConvertTo-MMUserStatus }
+        } elseif ($PSCmdlet.ParameterSetName -eq 'ByName') {
+            $resolvedId = (Get-MMUser -Username $Username).id
+            Invoke-MMRequest -Endpoint "users/$resolvedId/status" -Method GET | ConvertTo-MMUserStatus
         } else {
             Invoke-MMRequest -Endpoint "users/$UserId/status" -Method GET | ConvertTo-MMUserStatus
         }

--- a/MatterMostV4/Public/Teams/Get-MMTeam.ps1
+++ b/MatterMostV4/Public/Teams/Get-MMTeam.ps1
@@ -3,13 +3,15 @@
 function Get-MMTeam {
     <#
     .SYNOPSIS
-        Returns a MatterMost team by ID, name, or all teams.
+        Returns a MatterMost team by ID, name, all teams, or filtered by expression.
     .EXAMPLE
         Get-MMTeam -All
     .EXAMPLE
         Get-MMTeam -TeamId 'abc123'
     .EXAMPLE
         Get-MMTeam -Name 'testteam'
+    .EXAMPLE
+        Get-MMTeam -Filter { $_.name -like 'dev*' }
     #>
     [OutputType('MMTeam')]
     [CmdletBinding(DefaultParameterSetName = 'All')]
@@ -22,7 +24,10 @@ function Get-MMTeam {
         [string]$TeamId,
 
         [Parameter(Mandatory, ParameterSetName = 'ByName', Position = 0)]
-        [string]$Name
+        [string]$Name,
+
+        [Parameter(Mandatory, ParameterSetName = 'Filter')]
+        [scriptblock]$Filter
     )
 
     process {
@@ -30,6 +35,7 @@ function Get-MMTeam {
             'ById'   { Invoke-MMRequest -Endpoint "teams/$TeamId" | ConvertTo-MMTeam }
             'ByName' { Invoke-MMRequest -Endpoint "teams/name/$Name" | ConvertTo-MMTeam }
             'All'    { Get-MMTeamList | ConvertTo-MMTeam }
+            'Filter' { Get-MMTeamList | ConvertTo-MMTeam | Where-Object $Filter }
         }
     }
 }

--- a/MatterMostV4/Public/Teams/Get-MMTeamMembers.ps1
+++ b/MatterMostV4/Public/Teams/Get-MMTeamMembers.ps1
@@ -7,21 +7,32 @@ function Get-MMTeamMembers {
     .EXAMPLE
         Get-MMTeamMembers -TeamId 'abc123'
     .EXAMPLE
+        Get-MMTeamMembers -TeamName 'myteam'
+    .EXAMPLE
         Get-MMTeam -Name 'myteam' | Get-MMTeamMembers
     #>
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ById')]
     [OutputType('MMTeamMember')]
     param(
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'ById', ValueFromPipelineByPropertyName)]
         [Alias('id')]
-        [string]$TeamId
+        [string]$TeamId,
+
+        [Parameter(Mandatory, ParameterSetName = 'ByName')]
+        [string]$TeamName
     )
 
     process {
+        $resolvedId = if ($PSCmdlet.ParameterSetName -eq 'ByName') {
+            (Get-MMTeam -Name $TeamName).id
+        } else {
+            $TeamId
+        }
+
         $page    = 0
         $perPage = 200
         do {
-            $batch = Invoke-MMRequest -Endpoint "teams/$TeamId/members?page=$page&per_page=$perPage"
+            $batch = Invoke-MMRequest -Endpoint "teams/$resolvedId/members?page=$page&per_page=$perPage"
             $batch | ConvertTo-MMTeamMember
             $page++
         } while ($batch.Count -eq $perPage)

--- a/MatterMostV4/Public/Teams/Get-MMUserTeams.ps1
+++ b/MatterMostV4/Public/Teams/Get-MMUserTeams.ps1
@@ -7,17 +7,28 @@ function Get-MMUserTeams {
     .EXAMPLE
         Get-MMUserTeams -UserId 'abc123'
     .EXAMPLE
+        Get-MMUserTeams -Username 'jdoe'
+    .EXAMPLE
         Get-MMUser -Username 'jdoe' | Get-MMUserTeams
     #>
     [OutputType('MMTeam')]
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ById')]
     param(
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'ById', ValueFromPipelineByPropertyName)]
         [Alias('id')]
-        [string]$UserId
+        [string]$UserId,
+
+        [Parameter(Mandatory, ParameterSetName = 'ByName')]
+        [string]$Username
     )
 
     process {
-        Invoke-MMRequest -Endpoint "users/$UserId/teams" | ConvertTo-MMTeam
+        $resolvedId = if ($PSCmdlet.ParameterSetName -eq 'ByName') {
+            (Get-MMUser -Username $Username).id
+        } else {
+            $UserId
+        }
+
+        Invoke-MMRequest -Endpoint "users/$resolvedId/teams" | ConvertTo-MMTeam
     }
 }

--- a/MatterMostV4/Public/Teams/Send-MMTeamInvite.ps1
+++ b/MatterMostV4/Public/Teams/Send-MMTeamInvite.ps1
@@ -7,21 +7,32 @@ function Send-MMTeamInvite {
     .EXAMPLE
         Send-MMTeamInvite -TeamId 'abc123' -Emails 'user@example.com'
     .EXAMPLE
+        Send-MMTeamInvite -TeamName 'myteam' -Emails 'user@example.com'
+    .EXAMPLE
         Send-MMTeamInvite -TeamId 'abc123' -Emails 'user1@example.com', 'user2@example.com'
     .EXAMPLE
         Get-MMTeam -Name 'myteam' | Send-MMTeamInvite -Emails 'user@example.com'
     #>
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ById')]
     param(
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'ById', ValueFromPipelineByPropertyName)]
         [Alias('id')]
         [string]$TeamId,
+
+        [Parameter(Mandatory, ParameterSetName = 'ByName')]
+        [string]$TeamName,
 
         [Parameter(Mandatory)]
         [string[]]$Emails
     )
 
     process {
-        Invoke-MMRequest -Endpoint "teams/$TeamId/invite/email" -Method POST -Body $Emails
+        $resolvedId = if ($PSCmdlet.ParameterSetName -eq 'ByName') {
+            (Get-MMTeam -Name $TeamName).id
+        } else {
+            $TeamId
+        }
+
+        Invoke-MMRequest -Endpoint "teams/$resolvedId/invite/email" -Method POST -Body $Emails
     }
 }

--- a/MatterMostV4/Public/Users/Get-MMUserSession.ps1
+++ b/MatterMostV4/Public/Users/Get-MMUserSession.ps1
@@ -7,17 +7,28 @@ function Get-MMUserSession {
     .EXAMPLE
         Get-MMUserSession -UserId 'abc123'
     .EXAMPLE
+        Get-MMUserSession -Username 'jdoe'
+    .EXAMPLE
         Get-MMUser -Username 'jdoe' | Get-MMUserSession
     #>
     [OutputType('MMSession')]
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ById')]
     param(
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'ById', ValueFromPipelineByPropertyName)]
         [Alias('id')]
-        [string]$UserId
+        [string]$UserId,
+
+        [Parameter(Mandatory, ParameterSetName = 'ByName')]
+        [string]$Username
     )
 
     process {
-        Invoke-MMRequest -Endpoint "users/$UserId/sessions" | ConvertTo-MMSession
+        $resolvedId = if ($PSCmdlet.ParameterSetName -eq 'ByName') {
+            (Get-MMUser -Username $Username).id
+        } else {
+            $UserId
+        }
+
+        Invoke-MMRequest -Endpoint "users/$resolvedId/sessions" | ConvertTo-MMSession
     }
 }

--- a/MatterMostV4/Public/Users/Set-MMUserPassword.ps1
+++ b/MatterMostV4/Public/Users/Set-MMUserPassword.ps1
@@ -5,9 +5,9 @@ function Set-MMUserPassword {
     .SYNOPSIS
         Changes a MatterMost user password.
     .EXAMPLE
-        Set-MMUserPassword -UserId 'abc123' -NewPassword 'NewPass123!'
+        Set-MMUserPassword -UserId 'abc123' -NewPassword (ConvertTo-SecureString 'NewPass123!' -AsPlainText -Force)
     .EXAMPLE
-        Get-MMUser -Username 'jdoe' | Set-MMUserPassword -NewPassword 'NewPass123!'
+        Get-MMUser -Username 'jdoe' | Set-MMUserPassword -NewPassword (ConvertTo-SecureString 'NewPass123!' -AsPlainText -Force)
     #>
     [CmdletBinding()]
     param(

--- a/Pester/Integration/Bots.Tests.ps1
+++ b/Pester/Integration/Bots.Tests.ps1
@@ -74,6 +74,20 @@ Describe 'New-MMBot / Get-MMBot' {
         It 'бросает исключение при невалидном BotUserId' {
             { Get-MMBot -BotUserId 'invalid-bot-id' } | Should -Throw
         }
+
+        It 'возвращает ботов по -Filter на username' {
+            $botUsername = $script:Bot.username
+            $result      = Get-MMBot -Filter { $_.username -eq $botUsername }
+
+            $result          | Should -Not -BeNullOrEmpty
+            $result.username | Should -Be $script:Bot.username
+        }
+
+        It '-Filter возвращает пустой результат при несовпадении' {
+            $result = Get-MMBot -Filter { $_.username -eq 'nonexistent-bot-xyz-abc' }
+
+            $result | Should -BeNullOrEmpty
+        }
     }
 }
 

--- a/Pester/Integration/ChannelMembership.Tests.ps1
+++ b/Pester/Integration/ChannelMembership.Tests.ps1
@@ -85,6 +85,16 @@ Describe 'Get-MMUserChannels' {
             $channels = $script:TestUser | Get-MMUserChannels -TeamId $script:Team.id
             $channels | Should -Not -BeNullOrEmpty
         }
+
+        It 'возвращает членов канала по ChannelName' {
+            $result = Get-MMChannelMembers -ChannelName $script:Channel.name -TeamId $script:Team.id
+            $result | Should -Not -BeNullOrEmpty
+        }
+
+        It 'возвращает каналы по Username и TeamName' {
+            $channels = Get-MMUserChannels -Username $script:TestUser.username -TeamName $script:Team.name
+            $channels | Should -Not -BeNullOrEmpty
+        }
     }
 }
 

--- a/Pester/Integration/Files.Tests.ps1
+++ b/Pester/Integration/Files.Tests.ps1
@@ -52,6 +52,13 @@ Describe 'Send-MMFile' {
             $result.id | Should -Not -BeNullOrEmpty
         }
 
+        It 'загружает файл по ChannelName' {
+            $result = Send-MMFile -FilePath $script:TempFile -ChannelName $script:Channel.name
+
+            $result    | Should -Not -BeNullOrEmpty
+            $result.id | Should -Not -BeNullOrEmpty
+        }
+
         It 'бросает исключение если файл не существует' {
             { Send-MMFile -FilePath 'C:\nonexistent\file.txt' -ChannelId $script:Channel.id } |
                 Should -Throw

--- a/Pester/Integration/Get-MMChannel.Tests.ps1
+++ b/Pester/Integration/Get-MMChannel.Tests.ps1
@@ -103,4 +103,33 @@ Describe 'Get-MMChannel' {
             $result.name | Should -Be 'town-square'
         }
     }
+
+    Context '-Filter' {
+        It 'возвращает каналы по -eq на name' {
+            $result = Get-MMChannel -TeamId $script:Team.id -Filter { $_.name -eq 'town-square' }
+
+            $result      | Should -Not -BeNullOrEmpty
+            $result.name | Should -Be 'town-square'
+        }
+
+        It 'возвращает каналы по -like на name' {
+            $result = Get-MMChannel -TeamId $script:Team.id -Filter { $_.name -like 'town*' }
+
+            $result | Should -Not -BeNullOrEmpty
+            ($result | Where-Object { $_.name -like 'town*' }) | Should -Not -BeNullOrEmpty
+        }
+
+        It 'фильтрует по type' {
+            $result = Get-MMChannel -TeamId $script:Team.id -Filter { $_.type -eq 'O' }
+
+            $result | Should -Not -BeNullOrEmpty
+            $result | ForEach-Object { $_.type | Should -Be 'O' }
+        }
+
+        It 'возвращает пустой результат при несовпадении' {
+            $result = Get-MMChannel -TeamId $script:Team.id -Filter { $_.name -eq 'nonexistent-channel-xyz-abc' }
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
 }

--- a/Pester/Integration/Get-MMTeam.Tests.ps1
+++ b/Pester/Integration/Get-MMTeam.Tests.ps1
@@ -68,4 +68,27 @@ Describe 'Get-MMTeam' {
             $result.id | Should -Be $source.id
         }
     }
+
+    Context '-Filter' {
+        It 'возвращает команды по -eq на name' {
+            $teamName = $config.TestTeamName
+            $result   = Get-MMTeam -Filter { $_.name -eq $teamName }
+
+            $result      | Should -Not -BeNullOrEmpty
+            $result.name | Should -Be $config.TestTeamName
+        }
+
+        It 'возвращает команды по -like на name' {
+            $prefix = $config.TestTeamName.Substring(0, [Math]::Min(3, $config.TestTeamName.Length))
+            $result = Get-MMTeam -Filter ([scriptblock]::Create('$_.name -like "' + $prefix + '*"'))
+
+            $result | Should -Not -BeNullOrEmpty
+        }
+
+        It 'возвращает пустой результат при несовпадении' {
+            $result = Get-MMTeam -Filter { $_.name -eq 'nonexistent-team-xyz-abc' }
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
 }

--- a/Pester/Integration/Get-MMUserSession.Tests.ps1
+++ b/Pester/Integration/Get-MMUserSession.Tests.ps1
@@ -36,6 +36,11 @@ Describe 'Get-MMUserSession' {
             $result = $script:AdminUser | Get-MMUserSession
             $result | Should -Not -BeNullOrEmpty
         }
+
+        It 'возвращает сессии по Username' {
+            $result = Get-MMUserSession -Username $script:AdminUser.username
+            $result | Should -Not -BeNullOrEmpty
+        }
     }
 
     Context 'Ошибки' {

--- a/Pester/Integration/New-MMChannel.Tests.ps1
+++ b/Pester/Integration/New-MMChannel.Tests.ps1
@@ -68,6 +68,18 @@ Describe 'New-MMChannel' {
         }
     }
 
+    Context 'По TeamName' {
+        It 'создаёт канал по TeamName' {
+            $chan = New-MMChannel -TeamName $script:Team.name -Name "byname_$($script:Suffix)" -DisplayName 'ByName Channel'
+            try {
+                $chan      | Should -Not -BeNullOrEmpty
+                $chan.name | Should -Be "byname_$($script:Suffix)"
+            } finally {
+                Remove-MMChannel -ChannelId $chan.id
+            }
+        }
+    }
+
     Context 'Ошибки' {
         It 'бросает исключение при дублирующемся имени канала' {
             $tempChan = New-MMChannel -TeamId $script:Team.id -Name "dup_$($script:Suffix)" -DisplayName 'Dup Channel'

--- a/Pester/Integration/Posts.Tests.ps1
+++ b/Pester/Integration/Posts.Tests.ps1
@@ -192,6 +192,12 @@ Describe 'Get-MMChannelPosts' {
             $result | Should -Not -BeNullOrEmpty
         }
 
+        It 'возвращает посты по ChannelName' {
+            $result = Get-MMChannelPosts -ChannelName $script:Channel.name -PerPage 5
+
+            $result | Should -Not -BeNullOrEmpty
+        }
+
         It 'поддерживает пагинацию' {
             $page0 = Get-MMChannelPosts -ChannelId $script:Channel.id -Page 0 -PerPage 5
             $page1 = Get-MMChannelPosts -ChannelId $script:Channel.id -Page 1 -PerPage 5

--- a/Pester/Integration/Status.Tests.ps1
+++ b/Pester/Integration/Status.Tests.ps1
@@ -39,6 +39,13 @@ Describe 'Get-MMUserStatus' {
 
             $result.user_id | Should -Be $script:AdminUser.id
         }
+
+        It 'возвращает статус по Username' {
+            $result = Get-MMUserStatus -Username $script:AdminUser.username
+
+            $result.user_id        | Should -Be $script:AdminUser.id
+            $result.GetType().Name | Should -Be 'MMUserStatus'
+        }
     }
 
     Context 'Batch получение статусов по UserIds' {

--- a/Pester/Integration/TeamExtended.Tests.ps1
+++ b/Pester/Integration/TeamExtended.Tests.ps1
@@ -39,6 +39,13 @@ Describe 'Get-MMTeamMembers' {
 
             $result | Should -Not -BeNullOrEmpty
         }
+
+        It 'возвращает участников по TeamName' {
+            $result = Get-MMTeamMembers -TeamName $script:Team.name
+
+            $result            | Should -Not -BeNullOrEmpty
+            $result[0].team_id | Should -Be $script:Team.id
+        }
     }
 
     Context 'Ошибки' {
@@ -127,6 +134,14 @@ Describe 'Send-MMTeamInvite' {
         It 'принимает объект команды из пайплайна' {
             try {
                 $script:Team | Send-MMTeamInvite -Emails 'invite2@example.com'
+            } catch {
+                $_.Exception.Message | Should -Match '(disabled|invite|501|200)'
+            }
+        }
+
+        It 'отправляет приглашение по TeamName' {
+            try {
+                Send-MMTeamInvite -TeamName $script:Team.name -Emails 'invitename@example.com'
             } catch {
                 $_.Exception.Message | Should -Match '(disabled|invite|501|200)'
             }

--- a/Pester/Integration/TeamMembership.Tests.ps1
+++ b/Pester/Integration/TeamMembership.Tests.ps1
@@ -99,6 +99,11 @@ Describe 'Get-MMUserTeams' {
             $teams = $script:TestUser | Get-MMUserTeams
             $teams.id | Should -Contain $script:Team.id
         }
+
+        It 'возвращает команды по Username' {
+            $teams = Get-MMUserTeams -Username $script:TestUser.username
+            $teams.id | Should -Contain $script:Team.id
+        }
     }
 }
 

--- a/Pester/coverage.xml
+++ b/Pester/coverage.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd"[]>
-<report name="Pester (03/17/2026 12:14:00)">
-  <sessioninfo id="this" start="1773749588498" dump="1773749640386" />
+<report name="Pester (03/18/2026 08:24:30)">
+  <sessioninfo id="this" start="1773822220144" dump="1773822270001" />
   <package name="module">
     <class name="module/MatterMostV4" sourcefilename="MatterMostV4.psm1">
       <method name="&lt;script&gt;" desc="()" line="1">
@@ -601,13 +601,13 @@
       <counter type="CLASS" missed="0" covered="1" />
     </class>
     <class name="module/Public/Bots/Get-MMBot" sourcefilename="Public/Bots/Get-MMBot.ps1">
-      <method name="Get-MMBot" desc="()" line="36">
-        <counter type="INSTRUCTION" missed="0" covered="12" />
-        <counter type="LINE" missed="0" covered="7" />
+      <method name="Get-MMBot" desc="()" line="43">
+        <counter type="INSTRUCTION" missed="2" covered="25" />
+        <counter type="LINE" missed="0" covered="18" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <counter type="INSTRUCTION" missed="0" covered="12" />
-      <counter type="LINE" missed="0" covered="7" />
+      <counter type="INSTRUCTION" missed="2" covered="25" />
+      <counter type="LINE" missed="0" covered="18" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </class>
@@ -661,15 +661,26 @@
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
     <sourcefile name="Public/Bots/Get-MMBot.ps1">
-      <line nr="36" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="37" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="41" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="42" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="43" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="45" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="46" mi="0" ci="3" mb="0" cb="0" />
-      <counter type="INSTRUCTION" missed="0" covered="12" />
-      <counter type="LINE" missed="0" covered="7" />
+      <line nr="43" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="44" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="48" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="49" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="50" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="51" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="53" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="54" mi="1" ci="1" mb="0" cb="0" />
+      <line nr="55" mi="1" ci="1" mb="0" cb="0" />
+      <line nr="56" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="57" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="58" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="60" mi="0" ci="3" mb="0" cb="0" />
+      <line nr="64" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="65" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="66" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="68" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="69" mi="0" ci="3" mb="0" cb="0" />
+      <counter type="INSTRUCTION" missed="2" covered="25" />
+      <counter type="LINE" missed="0" covered="18" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
@@ -704,8 +715,8 @@
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
-    <counter type="INSTRUCTION" missed="1" covered="40" />
-    <counter type="LINE" missed="0" covered="24" />
+    <counter type="INSTRUCTION" missed="3" covered="53" />
+    <counter type="LINE" missed="0" covered="35" />
     <counter type="METHOD" missed="0" covered="6" />
     <counter type="CLASS" missed="0" covered="6" />
   </package>
@@ -722,46 +733,46 @@
       <counter type="CLASS" missed="0" covered="1" />
     </class>
     <class name="module/Public/Channels/Get-MMChannel" sourcefilename="Public/Channels/Get-MMChannel.ps1">
-      <method name="Get-MMChannel" desc="()" line="35">
-        <counter type="INSTRUCTION" missed="0" covered="23" />
-        <counter type="LINE" missed="0" covered="15" />
+      <method name="Get-MMChannel" desc="()" line="43">
+        <counter type="INSTRUCTION" missed="1" covered="34" />
+        <counter type="LINE" missed="0" covered="23" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <counter type="INSTRUCTION" missed="0" covered="23" />
-      <counter type="LINE" missed="0" covered="15" />
+      <counter type="INSTRUCTION" missed="1" covered="34" />
+      <counter type="LINE" missed="0" covered="23" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </class>
     <class name="module/Public/Channels/Get-MMChannelMembers" sourcefilename="Public/Channels/Get-MMChannelMembers.ps1">
-      <method name="Get-MMChannelMembers" desc="()" line="21">
-        <counter type="INSTRUCTION" missed="0" covered="6" />
-        <counter type="LINE" missed="0" covered="5" />
+      <method name="Get-MMChannelMembers" desc="()" line="29">
+        <counter type="INSTRUCTION" missed="0" covered="10" />
+        <counter type="LINE" missed="0" covered="8" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <counter type="INSTRUCTION" missed="0" covered="6" />
-      <counter type="LINE" missed="0" covered="5" />
+      <counter type="INSTRUCTION" missed="0" covered="10" />
+      <counter type="LINE" missed="0" covered="8" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </class>
     <class name="module/Public/Channels/Get-MMUserChannels" sourcefilename="Public/Channels/Get-MMUserChannels.ps1">
-      <method name="Get-MMUserChannels" desc="()" line="24">
-        <counter type="INSTRUCTION" missed="0" covered="2" />
-        <counter type="LINE" missed="0" covered="1" />
+      <method name="Get-MMUserChannels" desc="()" line="32">
+        <counter type="INSTRUCTION" missed="0" covered="10" />
+        <counter type="LINE" missed="0" covered="7" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <counter type="INSTRUCTION" missed="0" covered="2" />
-      <counter type="LINE" missed="0" covered="1" />
+      <counter type="INSTRUCTION" missed="0" covered="10" />
+      <counter type="LINE" missed="0" covered="7" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </class>
     <class name="module/Public/Channels/New-MMChannel" sourcefilename="Public/Channels/New-MMChannel.ps1">
-      <method name="New-MMChannel" desc="()" line="31">
-        <counter type="INSTRUCTION" missed="0" covered="16" />
-        <counter type="LINE" missed="0" covered="9" />
+      <method name="New-MMChannel" desc="()" line="36">
+        <counter type="INSTRUCTION" missed="0" covered="19" />
+        <counter type="LINE" missed="0" covered="13" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <counter type="INSTRUCTION" missed="0" covered="16" />
-      <counter type="LINE" missed="0" covered="9" />
+      <counter type="INSTRUCTION" missed="0" covered="19" />
+      <counter type="LINE" missed="0" covered="13" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </class>
@@ -850,56 +861,77 @@
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
     <sourcefile name="Public/Channels/Get-MMChannel.ps1">
-      <line nr="35" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="37" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="38" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="40" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="41" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="42" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="45" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="47" mi="0" ci="3" mb="0" cb="0" />
-      <line nr="48" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="51" mi="0" ci="3" mb="0" cb="0" />
-      <line nr="52" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="53" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="55" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="43" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="45" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="46" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="48" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="49" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="50" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="53" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="55" mi="0" ci="3" mb="0" cb="0" />
       <line nr="56" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="57" mi="0" ci="1" mb="0" cb="0" />
-      <counter type="INSTRUCTION" missed="0" covered="23" />
-      <counter type="LINE" missed="0" covered="15" />
+      <line nr="59" mi="0" ci="3" mb="0" cb="0" />
+      <line nr="60" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="61" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="63" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="64" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="65" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="69" mi="1" ci="2" mb="0" cb="0" />
+      <line nr="70" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="71" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="72" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="74" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="75" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="76" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="78" mi="0" ci="3" mb="0" cb="0" />
+      <counter type="INSTRUCTION" missed="1" covered="34" />
+      <counter type="LINE" missed="0" covered="23" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
     <sourcefile name="Public/Channels/Get-MMChannelMembers.ps1">
-      <line nr="21" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="22" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="24" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="25" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="26" mi="0" ci="1" mb="0" cb="0" />
-      <counter type="INSTRUCTION" missed="0" covered="6" />
-      <counter type="LINE" missed="0" covered="5" />
+      <line nr="29" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="30" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="32" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="35" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="36" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="38" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="39" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="40" mi="0" ci="1" mb="0" cb="0" />
+      <counter type="INSTRUCTION" missed="0" covered="10" />
+      <counter type="LINE" missed="0" covered="8" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
     <sourcefile name="Public/Channels/Get-MMUserChannels.ps1">
-      <line nr="24" mi="0" ci="2" mb="0" cb="0" />
-      <counter type="INSTRUCTION" missed="0" covered="2" />
-      <counter type="LINE" missed="0" covered="1" />
+      <line nr="32" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="33" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="35" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="38" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="39" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="41" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="44" mi="0" ci="2" mb="0" cb="0" />
+      <counter type="INSTRUCTION" missed="0" covered="10" />
+      <counter type="LINE" missed="0" covered="7" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
     <sourcefile name="Public/Channels/New-MMChannel.ps1">
-      <line nr="31" mi="0" ci="3" mb="0" cb="0" />
-      <line nr="33" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="34" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="35" mi="0" ci="1" mb="0" cb="0" />
       <line nr="36" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="37" mi="0" ci="3" mb="0" cb="0" />
-      <line nr="40" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="41" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="43" mi="0" ci="2" mb="0" cb="0" />
-      <counter type="INSTRUCTION" missed="0" covered="16" />
-      <counter type="LINE" missed="0" covered="9" />
+      <line nr="37" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="38" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="39" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="41" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="44" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="45" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="46" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="47" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="48" mi="0" ci="3" mb="0" cb="0" />
+      <line nr="51" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="52" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="54" mi="0" ci="2" mb="0" cb="0" />
+      <counter type="INSTRUCTION" missed="0" covered="19" />
+      <counter type="LINE" missed="0" covered="13" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
@@ -973,8 +1005,8 @@
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
-    <counter type="INSTRUCTION" missed="0" covered="84" />
-    <counter type="LINE" missed="0" covered="59" />
+    <counter type="INSTRUCTION" missed="1" covered="110" />
+    <counter type="LINE" missed="0" covered="80" />
     <counter type="METHOD" missed="0" covered="12" />
     <counter type="CLASS" missed="0" covered="12" />
   </package>
@@ -1253,13 +1285,13 @@
       <counter type="CLASS" missed="0" covered="1" />
     </class>
     <class name="module/Public/Files/Send-MMFile" sourcefilename="Public/Files/Send-MMFile.ps1">
-      <method name="Send-MMFile" desc="()" line="24">
-        <counter type="INSTRUCTION" missed="0" covered="2" />
-        <counter type="LINE" missed="0" covered="1" />
+      <method name="Send-MMFile" desc="()" line="32">
+        <counter type="INSTRUCTION" missed="0" covered="6" />
+        <counter type="LINE" missed="0" covered="4" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <counter type="INSTRUCTION" missed="0" covered="2" />
-      <counter type="LINE" missed="0" covered="1" />
+      <counter type="INSTRUCTION" missed="0" covered="6" />
+      <counter type="LINE" missed="0" covered="4" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </class>
@@ -1299,14 +1331,17 @@
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
     <sourcefile name="Public/Files/Send-MMFile.ps1">
-      <line nr="24" mi="0" ci="2" mb="0" cb="0" />
-      <counter type="INSTRUCTION" missed="0" covered="2" />
-      <counter type="LINE" missed="0" covered="1" />
+      <line nr="32" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="33" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="35" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="38" mi="0" ci="2" mb="0" cb="0" />
+      <counter type="INSTRUCTION" missed="0" covered="6" />
+      <counter type="LINE" missed="0" covered="4" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
-    <counter type="INSTRUCTION" missed="5" covered="19" />
-    <counter type="LINE" missed="4" covered="14" />
+    <counter type="INSTRUCTION" missed="5" covered="23" />
+    <counter type="LINE" missed="4" covered="17" />
     <counter type="METHOD" missed="0" covered="4" />
     <counter type="CLASS" missed="0" covered="4" />
   </package>
@@ -1323,13 +1358,13 @@
       <counter type="CLASS" missed="0" covered="1" />
     </class>
     <class name="module/Public/Posts/Get-MMChannelPosts" sourcefilename="Public/Posts/Get-MMChannelPosts.ps1">
-      <method name="Get-MMChannelPosts" desc="()" line="36">
-        <counter type="INSTRUCTION" missed="0" covered="10" />
-        <counter type="LINE" missed="0" covered="7" />
+      <method name="Get-MMChannelPosts" desc="()" line="43">
+        <counter type="INSTRUCTION" missed="0" covered="14" />
+        <counter type="LINE" missed="0" covered="10" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <counter type="INSTRUCTION" missed="0" covered="10" />
-      <counter type="LINE" missed="0" covered="7" />
+      <counter type="INSTRUCTION" missed="0" covered="14" />
+      <counter type="LINE" missed="0" covered="10" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </class>
@@ -1429,15 +1464,18 @@
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
     <sourcefile name="Public/Posts/Get-MMChannelPosts.ps1">
-      <line nr="36" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="37" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="38" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="40" mi="0" ci="1" mb="0" cb="0" />
       <line nr="43" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="44" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="45" mi="0" ci="2" mb="0" cb="0" />
-      <counter type="INSTRUCTION" missed="0" covered="10" />
-      <counter type="LINE" missed="0" covered="7" />
+      <line nr="44" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="46" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="49" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="50" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="51" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="53" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="55" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="56" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="57" mi="0" ci="2" mb="0" cb="0" />
+      <counter type="INSTRUCTION" missed="0" covered="14" />
+      <counter type="LINE" missed="0" covered="10" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
@@ -1551,8 +1589,8 @@
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
-    <counter type="INSTRUCTION" missed="0" covered="120" />
-    <counter type="LINE" missed="0" covered="70" />
+    <counter type="INSTRUCTION" missed="0" covered="124" />
+    <counter type="LINE" missed="0" covered="73" />
     <counter type="METHOD" missed="0" covered="10" />
     <counter type="CLASS" missed="0" covered="10" />
   </package>
@@ -1608,13 +1646,13 @@
   </package>
   <package name="module/Public/Status">
     <class name="module/Public/Status/Get-MMUserStatus" sourcefilename="Public/Status/Get-MMUserStatus.ps1">
-      <method name="Get-MMUserStatus" desc="()" line="26">
-        <counter type="INSTRUCTION" missed="0" covered="7" />
-        <counter type="LINE" missed="0" covered="4" />
+      <method name="Get-MMUserStatus" desc="()" line="31">
+        <counter type="INSTRUCTION" missed="0" covered="12" />
+        <counter type="LINE" missed="0" covered="7" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <counter type="INSTRUCTION" missed="0" covered="7" />
-      <counter type="LINE" missed="0" covered="4" />
+      <counter type="INSTRUCTION" missed="0" covered="12" />
+      <counter type="LINE" missed="0" covered="7" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </class>
@@ -1652,12 +1690,15 @@
       <counter type="CLASS" missed="0" covered="1" />
     </class>
     <sourcefile name="Public/Status/Get-MMUserStatus.ps1">
-      <line nr="26" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="27" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="28" mi="0" ci="3" mb="0" cb="0" />
-      <line nr="30" mi="0" ci="2" mb="0" cb="0" />
-      <counter type="INSTRUCTION" missed="0" covered="7" />
-      <counter type="LINE" missed="0" covered="4" />
+      <line nr="31" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="32" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="33" mi="0" ci="3" mb="0" cb="0" />
+      <line nr="34" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="35" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="36" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="38" mi="0" ci="2" mb="0" cb="0" />
+      <counter type="INSTRUCTION" missed="0" covered="12" />
+      <counter type="LINE" missed="0" covered="7" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
@@ -1694,8 +1735,8 @@
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
-    <counter type="INSTRUCTION" missed="2" covered="25" />
-    <counter type="LINE" missed="1" covered="18" />
+    <counter type="INSTRUCTION" missed="2" covered="30" />
+    <counter type="LINE" missed="1" covered="21" />
     <counter type="METHOD" missed="0" covered="4" />
     <counter type="CLASS" missed="0" covered="4" />
   </package>
@@ -1712,35 +1753,35 @@
       <counter type="CLASS" missed="0" covered="1" />
     </class>
     <class name="module/Public/Teams/Get-MMTeam" sourcefilename="Public/Teams/Get-MMTeam.ps1">
-      <method name="Get-MMTeam" desc="()" line="29">
-        <counter type="INSTRUCTION" missed="0" covered="7" />
-        <counter type="LINE" missed="0" covered="4" />
-        <counter type="METHOD" missed="0" covered="1" />
-      </method>
-      <counter type="INSTRUCTION" missed="0" covered="7" />
-      <counter type="LINE" missed="0" covered="4" />
-      <counter type="METHOD" missed="0" covered="1" />
-      <counter type="CLASS" missed="0" covered="1" />
-    </class>
-    <class name="module/Public/Teams/Get-MMTeamMembers" sourcefilename="Public/Teams/Get-MMTeamMembers.ps1">
-      <method name="Get-MMTeamMembers" desc="()" line="21">
-        <counter type="INSTRUCTION" missed="0" covered="6" />
+      <method name="Get-MMTeam" desc="()" line="34">
+        <counter type="INSTRUCTION" missed="0" covered="10" />
         <counter type="LINE" missed="0" covered="5" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <counter type="INSTRUCTION" missed="0" covered="6" />
+      <counter type="INSTRUCTION" missed="0" covered="10" />
       <counter type="LINE" missed="0" covered="5" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </class>
-    <class name="module/Public/Teams/Get-MMUserTeams" sourcefilename="Public/Teams/Get-MMUserTeams.ps1">
-      <method name="Get-MMUserTeams" desc="()" line="21">
-        <counter type="INSTRUCTION" missed="0" covered="2" />
-        <counter type="LINE" missed="0" covered="1" />
+    <class name="module/Public/Teams/Get-MMTeamMembers" sourcefilename="Public/Teams/Get-MMTeamMembers.ps1">
+      <method name="Get-MMTeamMembers" desc="()" line="26">
+        <counter type="INSTRUCTION" missed="0" covered="10" />
+        <counter type="LINE" missed="0" covered="8" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <counter type="INSTRUCTION" missed="0" covered="2" />
-      <counter type="LINE" missed="0" covered="1" />
+      <counter type="INSTRUCTION" missed="0" covered="10" />
+      <counter type="LINE" missed="0" covered="8" />
+      <counter type="METHOD" missed="0" covered="1" />
+      <counter type="CLASS" missed="0" covered="1" />
+    </class>
+    <class name="module/Public/Teams/Get-MMUserTeams" sourcefilename="Public/Teams/Get-MMUserTeams.ps1">
+      <method name="Get-MMUserTeams" desc="()" line="26">
+        <counter type="INSTRUCTION" missed="0" covered="6" />
+        <counter type="LINE" missed="0" covered="4" />
+        <counter type="METHOD" missed="0" covered="1" />
+      </method>
+      <counter type="INSTRUCTION" missed="0" covered="6" />
+      <counter type="LINE" missed="0" covered="4" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </class>
@@ -1789,13 +1830,13 @@
       <counter type="CLASS" missed="0" covered="1" />
     </class>
     <class name="module/Public/Teams/Send-MMTeamInvite" sourcefilename="Public/Teams/Send-MMTeamInvite.ps1">
-      <method name="Send-MMTeamInvite" desc="()" line="25">
-        <counter type="INSTRUCTION" missed="0" covered="1" />
-        <counter type="LINE" missed="0" covered="1" />
+      <method name="Send-MMTeamInvite" desc="()" line="30">
+        <counter type="INSTRUCTION" missed="0" covered="5" />
+        <counter type="LINE" missed="0" covered="4" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <counter type="INSTRUCTION" missed="0" covered="1" />
-      <counter type="LINE" missed="0" covered="1" />
+      <counter type="INSTRUCTION" missed="0" covered="5" />
+      <counter type="LINE" missed="0" covered="4" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </class>
@@ -1830,30 +1871,37 @@
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
     <sourcefile name="Public/Teams/Get-MMTeam.ps1">
-      <line nr="29" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="30" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="31" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="32" mi="0" ci="2" mb="0" cb="0" />
-      <counter type="INSTRUCTION" missed="0" covered="7" />
-      <counter type="LINE" missed="0" covered="4" />
-      <counter type="METHOD" missed="0" covered="1" />
-      <counter type="CLASS" missed="0" covered="1" />
-    </sourcefile>
-    <sourcefile name="Public/Teams/Get-MMTeamMembers.ps1">
-      <line nr="21" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="22" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="24" mi="0" ci="1" mb="0" cb="0" />
-      <line nr="25" mi="0" ci="2" mb="0" cb="0" />
-      <line nr="26" mi="0" ci="1" mb="0" cb="0" />
-      <counter type="INSTRUCTION" missed="0" covered="6" />
+      <line nr="34" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="35" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="36" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="37" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="38" mi="0" ci="3" mb="0" cb="0" />
+      <counter type="INSTRUCTION" missed="0" covered="10" />
       <counter type="LINE" missed="0" covered="5" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
+    <sourcefile name="Public/Teams/Get-MMTeamMembers.ps1">
+      <line nr="26" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="27" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="29" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="32" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="33" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="35" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="36" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="37" mi="0" ci="1" mb="0" cb="0" />
+      <counter type="INSTRUCTION" missed="0" covered="10" />
+      <counter type="LINE" missed="0" covered="8" />
+      <counter type="METHOD" missed="0" covered="1" />
+      <counter type="CLASS" missed="0" covered="1" />
+    </sourcefile>
     <sourcefile name="Public/Teams/Get-MMUserTeams.ps1">
-      <line nr="21" mi="0" ci="2" mb="0" cb="0" />
-      <counter type="INSTRUCTION" missed="0" covered="2" />
-      <counter type="LINE" missed="0" covered="1" />
+      <line nr="26" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="27" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="29" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="32" mi="0" ci="2" mb="0" cb="0" />
+      <counter type="INSTRUCTION" missed="0" covered="6" />
+      <counter type="LINE" missed="0" covered="4" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
@@ -1895,9 +1943,12 @@
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
     <sourcefile name="Public/Teams/Send-MMTeamInvite.ps1">
-      <line nr="25" mi="0" ci="1" mb="0" cb="0" />
-      <counter type="INSTRUCTION" missed="0" covered="1" />
-      <counter type="LINE" missed="0" covered="1" />
+      <line nr="30" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="31" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="33" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="36" mi="0" ci="1" mb="0" cb="0" />
+      <counter type="INSTRUCTION" missed="0" covered="5" />
+      <counter type="LINE" missed="0" covered="4" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
@@ -1929,8 +1980,8 @@
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
-    <counter type="INSTRUCTION" missed="0" covered="62" />
-    <counter type="LINE" missed="0" covered="42" />
+    <counter type="INSTRUCTION" missed="0" covered="77" />
+    <counter type="LINE" missed="0" covered="52" />
     <counter type="METHOD" missed="0" covered="11" />
     <counter type="CLASS" missed="0" covered="11" />
   </package>
@@ -2007,13 +2058,13 @@
       <counter type="CLASS" missed="0" covered="1" />
     </class>
     <class name="module/Public/Users/Get-MMUserSession" sourcefilename="Public/Users/Get-MMUserSession.ps1">
-      <method name="Get-MMUserSession" desc="()" line="21">
-        <counter type="INSTRUCTION" missed="0" covered="2" />
-        <counter type="LINE" missed="0" covered="1" />
+      <method name="Get-MMUserSession" desc="()" line="26">
+        <counter type="INSTRUCTION" missed="0" covered="6" />
+        <counter type="LINE" missed="0" covered="4" />
         <counter type="METHOD" missed="0" covered="1" />
       </method>
-      <counter type="INSTRUCTION" missed="0" covered="2" />
-      <counter type="LINE" missed="0" covered="1" />
+      <counter type="INSTRUCTION" missed="0" covered="6" />
+      <counter type="LINE" missed="0" covered="4" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </class>
@@ -2204,9 +2255,12 @@
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
     <sourcefile name="Public/Users/Get-MMUserSession.ps1">
-      <line nr="21" mi="0" ci="2" mb="0" cb="0" />
-      <counter type="INSTRUCTION" missed="0" covered="2" />
-      <counter type="LINE" missed="0" covered="1" />
+      <line nr="26" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="27" mi="0" ci="2" mb="0" cb="0" />
+      <line nr="29" mi="0" ci="1" mb="0" cb="0" />
+      <line nr="32" mi="0" ci="2" mb="0" cb="0" />
+      <counter type="INSTRUCTION" missed="0" covered="6" />
+      <counter type="LINE" missed="0" covered="4" />
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
@@ -2324,8 +2378,8 @@
       <counter type="METHOD" missed="0" covered="1" />
       <counter type="CLASS" missed="0" covered="1" />
     </sourcefile>
-    <counter type="INSTRUCTION" missed="0" covered="115" />
-    <counter type="LINE" missed="0" covered="78" />
+    <counter type="INSTRUCTION" missed="0" covered="119" />
+    <counter type="LINE" missed="0" covered="81" />
     <counter type="METHOD" missed="0" covered="19" />
     <counter type="CLASS" missed="0" covered="18" />
   </package>
@@ -2559,8 +2613,8 @@
     <counter type="METHOD" missed="0" covered="9" />
     <counter type="CLASS" missed="0" covered="9" />
   </package>
-  <counter type="INSTRUCTION" missed="26" covered="933" />
-  <counter type="LINE" missed="21" covered="656" />
+  <counter type="INSTRUCTION" missed="29" covered="1004" />
+  <counter type="LINE" missed="21" covered="710" />
   <counter type="METHOD" missed="0" covered="106" />
   <counter type="CLASS" missed="0" covered="105" />
 </report>


### PR DESCRIPTION
1. [UX] PascalCase алиасы свойств через Types.ps1xml
Новый файл MatterMost.Types.ps1xml — ScriptProperty алиасы для всех 15 типов
Теперь Select-Object ChannelId вместо Select-Object 'Channel Id'
Все 15 Format.ps1xml синхронизированы — лейблы и PropertyName теперь PascalCase

2. [UX] -Username / -TeamName / -ChannelName резолв
Get-MMUserSession, Get-MMUserStatus, Get-MMUserChannels, Get-MMUserTeams — добавлен -Username
Get-MMChannelMembers, Get-MMChannelPosts — добавлен -ChannelName [-TeamId]
Get-MMTeamMembers — добавлен -TeamName
New-MMChannel, Send-MMTeamInvite — добавлен -TeamName
Send-MMFile — добавлен -ChannelName [-TeamId]

3. [UX] Фиксы в примерах документации
Connect-MMServer — исправлен Example 1 (SecureString вместо строки)
Set-MMUserPassword — исправлены оба примера

4. [Feature] -Filter для Get-MMChannel / Get-MMTeam / Get-MMBot
Синтаксис: Get-MMChannel -Filter { $_.name -like 'dev*' }
Клиентская фильтрация после fetch all; Get-MMBot -Filter поддерживает -IncludeDeleted / -OnlyOrphaned